### PR TITLE
🧹 Refactor PageViewport render logic and clean up debug logs

### DIFF
--- a/src/ui/pages/PageViewport.ts
+++ b/src/ui/pages/PageViewport.ts
@@ -31,90 +31,64 @@ export class PageViewport {
     this.pageLayer.render(layout);
     this.mapper = new SelectionMapper(layout, this.measurer);
 
-    // Clear old overlays
-    this.caretOverlays.forEach((o) => o.render(null));
-    this.selectionOverlays.forEach((o) => o.render(null));
+    this.clearOverlays();
 
     if (!selection) return;
 
-    // Handle caret
-    if (
+    if (this.isCaretSelection(selection)) {
+      this.renderCaret(selection.anchor || selection.focus);
+    } else {
+      this.renderSelectionRange(selection);
+    }
+  }
+
+  private clearOverlays(): void {
+    this.caretOverlays.forEach((o) => o.render(null));
+    this.selectionOverlays.forEach((o) => o.render(null));
+  }
+
+  private isCaretSelection(selection: EditorSelection): boolean {
+    return (
       !selection.anchor ||
       (selection.anchor.offset === selection.focus.offset &&
         selection.anchor.blockId === selection.focus.blockId)
-    ) {
-      console.log("VIEWPORT: Renderizando caret");
-      console.log(
-        "VIEWPORT: Posição do caret:",
-        selection.anchor || selection.focus,
-      );
-      const caretRect = this.mapper.getCaretRect(
-        selection.anchor || selection.focus,
-      );
-      console.log("VIEWPORT: Caret rect:", caretRect);
-      if (caretRect) {
-        this.getOrCreateCaretOverlay(caretRect.pageId).render(
-          selection.anchor || selection.focus,
-        );
-      }
-    } else {
-      // Handle selection
-      const range = this.normalizeSelection(selection);
-      const rects = this.mapper.getSelectionRects(range);
-      rects.forEach((rect) => {
-        this.getOrCreateSelectionOverlay(rect.pageId).render(range);
-      });
+    );
+  }
+
+  private renderCaret(position: LogicalPosition): void {
+    const caretRect = this.mapper!.getCaretRect(position);
+    if (caretRect) {
+      this.getOrCreateCaretOverlay(caretRect.pageId).render(position);
     }
+  }
+
+  private renderSelectionRange(selection: EditorSelection): void {
+    const range = this.normalizeSelection(selection);
+    const rects = this.mapper!.getSelectionRects(range);
+    rects.forEach((rect) => {
+      this.getOrCreateSelectionOverlay(rect.pageId).render(range);
+    });
   }
 
   getOrCreateCaretOverlay(
     pageId: string,
   ): CaretOverlay | { render: () => void } {
-    console.log(
-      "VIEWPORT: getOrCreateCaretOverlay chamado com pageId:",
-      pageId,
-    );
     if (this.caretOverlays.has(pageId)) {
       const existingOverlay = this.caretOverlays.get(pageId)!;
-      const isInDOM = document.body.contains(
-        existingOverlay.container as unknown as Node,
-      );
-      console.log("VIEWPORT: Overlay existente ainda está no DOM?", isInDOM);
-      if (!isInDOM) {
-        console.log(
-          "VIEWPORT: Container antigo foi removido, recriando overlay",
-        );
-        this.caretOverlays.delete(pageId);
+      if (
+        document.body.contains(existingOverlay.container as unknown as Node)
+      ) {
+        return existingOverlay;
       }
+      this.caretOverlays.delete(pageId);
     }
 
-    if (!this.caretOverlays.has(pageId)) {
-      console.log("VIEWPORT: Criando novo caret overlay para pagina:", pageId);
-      const pageEl = this.root.querySelector(`[data-page-id="${pageId}"]`);
-      console.log("VIEWPORT: Elemento da pagina encontrado?", !!pageEl);
-      if (!pageEl) {
-        console.log("VIEWPORT: ❌ Pagina nao encontrada, retornando stub");
-        return { render: () => {} };
-      }
+    const container = this.getOverlayContainer(pageId);
+    if (!container) return { render: () => {} };
 
-      let overlayContainer = pageEl.querySelector(
-        ".oasis-selection-layer",
-      ) as HTMLElement | null;
-      console.log("VIEWPORT: Container de selecao existe?", !!overlayContainer);
-      if (!overlayContainer) {
-        console.log("VIEWPORT: Criando novo container de selecao");
-        overlayContainer = document.createElement("div");
-        overlayContainer.className = "oasis-selection-layer";
-        pageEl.appendChild(overlayContainer);
-      }
-
-      this.caretOverlays.set(
-        pageId,
-        new CaretOverlay(overlayContainer, this.mapper!),
-      );
-      console.log("VIEWPORT: CaretOverlay criado e armazenado");
-    }
-    return this.caretOverlays.get(pageId)!;
+    const overlay = new CaretOverlay(container, this.mapper!);
+    this.caretOverlays.set(pageId, overlay);
+    return overlay;
   }
 
   getOrCreateSelectionOverlay(
@@ -122,33 +96,37 @@ export class PageViewport {
   ): SelectionOverlay | { render: () => void } {
     if (this.selectionOverlays.has(pageId)) {
       const existingOverlay = this.selectionOverlays.get(pageId)!;
-      const isInDOM = document.body.contains(
-        existingOverlay.container as unknown as Node,
-      );
-      if (!isInDOM) {
-        this.selectionOverlays.delete(pageId);
+      if (
+        document.body.contains(existingOverlay.container as unknown as Node)
+      ) {
+        return existingOverlay;
       }
+      this.selectionOverlays.delete(pageId);
     }
 
-    if (!this.selectionOverlays.has(pageId)) {
-      const pageEl = this.root.querySelector(`[data-page-id="${pageId}"]`);
-      if (!pageEl) return { render: () => {} };
+    const container = this.getOverlayContainer(pageId);
+    if (!container) return { render: () => {} };
 
-      let overlayContainer = pageEl.querySelector(
-        ".oasis-selection-layer",
-      ) as HTMLElement | null;
-      if (!overlayContainer) {
-        overlayContainer = document.createElement("div");
-        overlayContainer.className = "oasis-selection-layer";
-        pageEl.appendChild(overlayContainer);
-      }
+    const overlay = new SelectionOverlay(container, this.mapper!);
+    this.selectionOverlays.set(pageId, overlay);
+    return overlay;
+  }
 
-      this.selectionOverlays.set(
-        pageId,
-        new SelectionOverlay(overlayContainer, this.mapper!),
-      );
+  private getOverlayContainer(pageId: string): HTMLElement | null {
+    const pageEl = this.root.querySelector(`[data-page-id="${pageId}"]`);
+    if (!pageEl) return null;
+
+    let overlayContainer = pageEl.querySelector(
+      ".oasis-selection-layer",
+    ) as HTMLElement | null;
+
+    if (!overlayContainer) {
+      overlayContainer = document.createElement("div");
+      overlayContainer.className = "oasis-selection-layer";
+      pageEl.appendChild(overlayContainer);
     }
-    return this.selectionOverlays.get(pageId)!;
+
+    return overlayContainer;
   }
 
   normalizeSelection(selection: EditorSelection): LogicalRange {

--- a/src/ui/selection/CaretOverlay.ts
+++ b/src/ui/selection/CaretOverlay.ts
@@ -11,26 +11,13 @@ export class CaretOverlay {
   }
 
   render(position: LogicalPosition | null): void {
-    console.log("CARET_OVERLAY: render chamado", position);
-    console.log("CARET_OVERLAY: Container antes:", this.container);
-    console.log(
-      "CARET_OVERLAY: Filhos no container:",
-      this.container.children.length,
-    );
     this.container.innerHTML = "";
-    console.log(
-      "CARET_OVERLAY: Container limpo, filhos:",
-      this.container.children.length,
-    );
     if (!position || !this.mapper?.getCaretRect) {
-      console.log("CARET_OVERLAY: Posição ou mapper inválido, saindo");
       return;
     }
 
     const rect = this.mapper.getCaretRect(position);
-    console.log("CARET_OVERLAY: rect calculado:", rect);
     if (!rect) {
-      console.log("CARET_OVERLAY: rect é null, saindo");
       return;
     }
 
@@ -39,49 +26,7 @@ export class CaretOverlay {
     el.style.left = `${rect.x}px`;
     el.style.top = `${rect.y}px`;
     el.style.height = `${rect.height}px`;
-    console.log("CARET_OVERLAY: Elemento caret criado:", {
-      left: el.style.left,
-      top: el.style.top,
-      height: el.style.height,
-      className: el.className,
-    });
 
-    // Verificar estilos computados
     this.container.appendChild(el);
-    console.log("CARET_OVERLAY: Caret adicionado ao container");
-    console.log(
-      "CARET_OVERLAY: Container depois, filhos:",
-      this.container.children.length,
-    );
-    console.log("CARET_OVERLAY: Container dimensões:", {
-      offsetWidth: this.container.offsetWidth,
-      offsetHeight: this.container.offsetHeight,
-      position: getComputedStyle(this.container).position,
-      zIndex: getComputedStyle(this.container).zIndex,
-      display: getComputedStyle(this.container).display,
-    });
-
-    const caretEl = this.container.querySelector(".oasis-caret");
-    if (caretEl) {
-      console.log("CARET_OVERLAY: Caret element encontrado:", caretEl);
-      console.log("CARET_OVERLAY: Caret estilos computados:", {
-        width: getComputedStyle(caretEl).width,
-        height: getComputedStyle(caretEl).height,
-        left: getComputedStyle(caretEl).left,
-        top: getComputedStyle(caretEl).top,
-        background: getComputedStyle(caretEl).background,
-        display: getComputedStyle(caretEl).display,
-        opacity: getComputedStyle(caretEl).opacity,
-        position: getComputedStyle(caretEl).position,
-        zIndex: getComputedStyle(caretEl).zIndex,
-        visibility: getComputedStyle(caretEl).visibility,
-      });
-    } else {
-      console.log("CARET_OVERLAY: ❌ Caret element NÃO encontrada no DOM!");
-      console.log(
-        "CARET_OVERLAY: Container innerHTML:",
-        this.container.innerHTML,
-      );
-    }
   }
 }


### PR DESCRIPTION
This PR improves the maintainability and readability of `PageViewport.ts` by:
- Breaking down the high-complexity `render` method into smaller, specialized private methods (`clearOverlays`, `isCaretSelection`, `renderCaret`, `renderSelectionRange`).
- Reducing code duplication in overlay management by introducing a `getOverlayContainer` helper.
- Cleaning up technical debt by removing legacy debug logs in `PageViewport.ts` and `CaretOverlay.ts`.

Verification:
- Structural changes confirmed via `read_file`.
- Overall stability and logic verified by running existing tests with `bun test`.
- All tests passed.

---
*PR created automatically by Jules for task [14149827511722641148](https://jules.google.com/task/14149827511722641148) started by @celsowm*