### PR TITLE
🧹 Refactor SelectionMapper to reduce complexity

### DIFF
--- a/src/__tests__/SelectionMapper.test.ts
+++ b/src/__tests__/SelectionMapper.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import { SelectionMapper } from "../app/services/SelectionMapper.js";
+import { LayoutState } from "../core/layout/LayoutTypes.js";
+import { TextMeasurer } from "../bridge/measurement/TextMeasurementBridge.js";
+import { LogicalRange } from "../core/selection/SelectionTypes.js";
+
+describe("SelectionMapper", () => {
+  const mockMeasurer: TextMeasurer = {
+    measureText: vi.fn().mockReturnValue({ width: 50, height: 20 }),
+  };
+
+  const mockLayout: LayoutState = {
+    pages: [
+      {
+        id: "page-1",
+        sectionId: "section-1",
+        pageIndex: 0,
+        pageNumber: "1",
+        rect: { x: 0, y: 0, width: 800, height: 1000 },
+        contentRect: { x: 50, y: 50, width: 700, height: 900 },
+        templateId: "default",
+        headerRect: null,
+        footerRect: null,
+        fragments: [
+          {
+            id: "frag-1",
+            blockId: "block-1",
+            sectionId: "section-1",
+            pageId: "page-1",
+            fragmentIndex: 0,
+            kind: "paragraph",
+            startOffset: 0,
+            endOffset: 11,
+            text: "Hello World",
+            rect: { x: 50, y: 50, width: 700, height: 100 },
+            typography: { fontFamily: "Arial", fontSize: 12, fontWeight: 400 },
+            marks: {},
+            runs: [{ id: "run-1", text: "Hello World", marks: {} }],
+            lines: [
+              {
+                id: "line-1",
+                text: "Hello World",
+                width: 100,
+                height: 20,
+                x: 0,
+                y: 50,
+                offsetStart: 0,
+                offsetEnd: 11,
+              },
+            ],
+            align: "left",
+          },
+          {
+            id: "frag-2",
+            blockId: "block-2",
+            sectionId: "section-1",
+            pageId: "page-1",
+            fragmentIndex: 0,
+            kind: "paragraph",
+            startOffset: 0,
+            endOffset: 11,
+            text: "Next Paragraph",
+            rect: { x: 50, y: 150, width: 700, height: 100 },
+            typography: { fontFamily: "Arial", fontSize: 12, fontWeight: 400 },
+            marks: {},
+            runs: [{ id: "run-2", text: "Next Paragraph", marks: {} }],
+            lines: [
+              {
+                id: "line-2",
+                text: "Next Paragraph",
+                width: 100,
+                height: 20,
+                x: 0,
+                y: 150,
+                offsetStart: 0,
+                offsetEnd: 14,
+              },
+            ],
+            align: "left",
+          },
+        ],
+      },
+    ],
+    fragmentsByBlockId: {},
+  };
+  mockLayout.fragmentsByBlockId["block-1"] = [mockLayout.pages[0].fragments[0]];
+  mockLayout.fragmentsByBlockId["block-2"] = [mockLayout.pages[0].fragments[1]];
+
+  it("should return correct selection rect for a single line selection", () => {
+    const mapper = new SelectionMapper(mockLayout, mockMeasurer);
+    const range: LogicalRange = {
+      start: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 0 },
+      end: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 5 },
+    };
+
+    const rects = mapper.getSelectionRects(range);
+    expect(rects.length).toBe(1);
+    expect(rects[0].pageId).toBe("page-1");
+    expect(rects[0].y).toBe(50);
+    expect(rects[0].height).toBe(20);
+  });
+
+  it("should handle reversed range", () => {
+    const mapper = new SelectionMapper(mockLayout, mockMeasurer);
+    const range: LogicalRange = {
+      start: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 5 },
+      end: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 0 },
+    };
+
+    const rects = mapper.getSelectionRects(range);
+    expect(rects.length).toBe(1);
+    expect(rects[0].pageId).toBe("page-1");
+  });
+
+  it("should handle multi-block selection", () => {
+    const mapper = new SelectionMapper(mockLayout, mockMeasurer);
+    const range: LogicalRange = {
+      start: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 0 },
+      end: { sectionId: "section-1", blockId: "block-2", inlineId: "run-2", offset: 5 },
+    };
+
+    const rects = mapper.getSelectionRects(range);
+    expect(rects.length).toBe(2);
+    expect(rects[0].y).toBe(50);
+    expect(rects[1].y).toBe(150);
+  });
+
+  it("should handle reversed multi-block selection", () => {
+    const mapper = new SelectionMapper(mockLayout, mockMeasurer);
+    const range: LogicalRange = {
+      start: { sectionId: "section-1", blockId: "block-2", inlineId: "run-2", offset: 5 },
+      end: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 0 },
+    };
+
+    const rects = mapper.getSelectionRects(range);
+    expect(rects.length).toBe(2);
+    expect(rects[0].y).toBe(50);
+    expect(rects[1].y).toBe(150);
+  });
+
+  it("should return empty array for invalid range", () => {
+    const mapper = new SelectionMapper(mockLayout, mockMeasurer);
+    const range: LogicalRange = {
+      start: null as any,
+      end: { sectionId: "section-1", blockId: "block-1", inlineId: "run-1", offset: 5 },
+    };
+
+    const rects = mapper.getSelectionRects(range);
+    expect(rects).toEqual([]);
+  });
+});

--- a/src/app/services/SelectionMapper.ts
+++ b/src/app/services/SelectionMapper.ts
@@ -3,7 +3,7 @@ import {
   LogicalRange,
 } from "../../core/selection/SelectionTypes.js";
 import { LayoutState } from "../../core/layout/LayoutTypes.js";
-import { LayoutFragment } from "../../core/layout/LayoutFragment.js";
+import { LayoutFragment, LineInfo } from "../../core/layout/LayoutFragment.js";
 import { TextMeasurer } from "../../bridge/measurement/TextMeasurementBridge.js";
 import { PositionCalculator } from "./PositionCalculator.js";
 
@@ -57,14 +57,89 @@ export class SelectionMapper {
     };
   }
 
+  /**
+   * Calculates the set of rectangles that represent the selection for a given logical range.
+   * Selection can span multiple lines, fragments, and pages.
+   */
   getSelectionRects(range: LogicalRange): SelectionRect[] {
     const { start, end } = range;
 
-    const startRect = this.getCaretRect(start);
-    const endRect = this.getCaretRect(end);
+    // Get carets for both ends of the range to facilitate width calculations
+    const startCaret = this.getCaretRect(start);
+    const endCaret = this.getCaretRect(end);
 
-    if (!startRect || !endRect) return [];
+    if (!startCaret || !endCaret) return [];
 
+    // Ensure we process the range from top-to-bottom in the document flow
+    const normalized = this.normalizeRange(range);
+    if (!normalized) return [];
+
+    const { visualStart, visualEnd, visualStartAbs, visualEndAbs } = normalized;
+
+    const visualStartCaret = visualStart === start ? startCaret : endCaret;
+    const visualEndCaret = visualEnd === end ? endCaret : startCaret;
+
+    const rects: SelectionRect[] = [];
+    let isCurrentlyInSelection = false;
+    let isSelectionFinished = false;
+
+    for (const page of this.layout.pages) {
+      for (const fragment of page.fragments) {
+        if (!fragment.lines) continue;
+
+        for (const line of fragment.lines) {
+          const isLineWhereSelectionStarts =
+            !isCurrentlyInSelection &&
+            fragment.blockId === visualStart.blockId &&
+            visualStartAbs >= line.offsetStart &&
+            visualStartAbs <= line.offsetEnd;
+
+          if (isLineWhereSelectionStarts) {
+            isCurrentlyInSelection = true;
+          }
+
+          const isLineWhereSelectionEnds =
+            isCurrentlyInSelection &&
+            fragment.blockId === visualEnd.blockId &&
+            visualEndAbs >= line.offsetStart &&
+            visualEndAbs <= line.offsetEnd;
+
+          if (isLineWhereSelectionEnds) {
+            isSelectionFinished = true;
+          }
+
+          if (isCurrentlyInSelection) {
+            const rect = this.calculateRectForLine(
+              line,
+              fragment,
+              page.id,
+              isLineWhereSelectionStarts,
+              isLineWhereSelectionEnds,
+              visualStartCaret.x,
+              visualEndCaret.x,
+            );
+
+            if (rect) {
+              rects.push(rect);
+            }
+          }
+
+          if (isSelectionFinished) break;
+        }
+        if (isSelectionFinished) break;
+      }
+      if (isSelectionFinished) break;
+    }
+
+    return rects;
+  }
+
+  /**
+   * Normalizes a selection range so that visualStart always appears before visualEnd
+   * in the document flow. This handles cases where the user selects text backwards.
+   */
+  private normalizeRange(range: LogicalRange) {
+    const { start, end } = range;
     const absStartOffset = this.positionCalculator.getOffsetInBlock(start);
     const absEndOffset = this.positionCalculator.getOffsetInBlock(end);
 
@@ -73,12 +148,13 @@ export class SelectionMapper {
     let visualStartAbs = 0;
     let visualEndAbs = 0;
 
+    // Scan the layout to see which block (start or end) appears first.
     for (const page of this.layout.pages) {
       for (const fragment of page.fragments) {
-        if (
-          fragment.blockId === start.blockId &&
-          fragment.blockId === end.blockId
-        ) {
+        const isStartBlock = fragment.blockId === start.blockId;
+        const isEndBlock = fragment.blockId === end.blockId;
+
+        if (isStartBlock && isEndBlock) {
           if (absStartOffset <= absEndOffset) {
             visualStart = start;
             visualEnd = end;
@@ -92,14 +168,16 @@ export class SelectionMapper {
           }
           break;
         }
-        if (fragment.blockId === start.blockId && !visualStart) {
+
+        if (isStartBlock && !visualStart) {
           visualStart = start;
           visualEnd = end;
           visualStartAbs = absStartOffset;
           visualEndAbs = absEndOffset;
           break;
         }
-        if (fragment.blockId === end.blockId && !visualStart) {
+
+        if (isEndBlock && !visualStart) {
           visualStart = end;
           visualEnd = start;
           visualStartAbs = absEndOffset;
@@ -110,77 +188,46 @@ export class SelectionMapper {
       if (visualStart) break;
     }
 
-    if (!visualStart || !visualEnd) return [];
+    if (!visualStart || !visualEnd) return null;
 
-    const vStartRect = visualStart === start ? startRect : endRect;
-    const vEndRect = visualEnd === end ? endRect : startRect;
+    return { visualStart, visualEnd, visualStartAbs, visualEndAbs };
+  }
 
-    const rects: SelectionRect[] = [];
-    let inSelection = false;
-    let done = false;
+  /**
+   * Calculates the selection rectangle for a single line of text.
+   */
+  private calculateRectForLine(
+    line: LineInfo,
+    fragment: LayoutFragment,
+    pageId: string,
+    isLineStart: boolean,
+    isLineEnd: boolean,
+    visualStartX: number,
+    visualEndX: number,
+  ): SelectionRect | null {
+    let x = fragment.rect.x;
+    let width = line.width ?? fragment.rect.width;
 
-    for (const page of this.layout.pages) {
-      for (const fragment of page.fragments) {
-        if (!fragment.lines) continue;
-
-        for (const line of fragment.lines) {
-          let lineMatchesStart = false;
-          let lineMatchesEnd = false;
-
-          if (
-            !inSelection &&
-            fragment.blockId === visualStart.blockId &&
-            visualStartAbs >= line.offsetStart &&
-            visualStartAbs <= line.offsetEnd
-          ) {
-            inSelection = true;
-            lineMatchesStart = true;
-          }
-
-          if (
-            inSelection &&
-            fragment.blockId === visualEnd.blockId &&
-            visualEndAbs >= line.offsetStart &&
-            visualEndAbs <= line.offsetEnd
-          ) {
-            lineMatchesEnd = true;
-            done = true;
-          }
-
-          if (inSelection) {
-            let x = fragment.rect.x;
-            let width = line.width ?? fragment.rect.width;
-
-            if (lineMatchesStart && lineMatchesEnd) {
-              x = vStartRect.x;
-              width = Math.max(vEndRect.x - vStartRect.x, 2);
-            } else if (lineMatchesStart) {
-              x = vStartRect.x;
-              const lineEndX = fragment.rect.x + (line.width ?? fragment.rect.width);
-              width = Math.max(lineEndX - vStartRect.x, 2);
-            } else if (lineMatchesEnd) {
-              x = fragment.rect.x;
-              width = Math.max(vEndRect.x - fragment.rect.x, 2);
-            }
-
-            if (width > 0) {
-              rects.push({
-                x,
-                y: line.y,
-                width,
-                height: line.height,
-                pageId: page.id,
-              });
-            }
-          }
-
-          if (done) break;
-        }
-        if (done) break;
-      }
-      if (done) break;
+    if (isLineStart && isLineEnd) {
+      x = visualStartX;
+      width = Math.max(visualEndX - visualStartX, 2);
+    } else if (isLineStart) {
+      x = visualStartX;
+      const lineEndX = fragment.rect.x + (line.width ?? fragment.rect.width);
+      width = Math.max(lineEndX - visualStartX, 2);
+    } else if (isLineEnd) {
+      x = fragment.rect.x;
+      width = Math.max(visualEndX - fragment.rect.x, 2);
     }
 
-    return rects;
+    if (width <= 0) return null;
+
+    return {
+      x,
+      y: line.y,
+      width,
+      height: line.height,
+      pageId: pageId,
+    };
   }
 }


### PR DESCRIPTION
The `getSelectionRects` function in `SelectionMapper.ts` was identified as having high complexity. I refactored it by extracting the range normalization and line-by-line rectangle calculation into private helper methods. To ensure no regressions were introduced, I created a new test suite that covers various selection scenarios, including multi-block and reversed selections. All tests passed, and a code review confirmed the correctness and safety of the refactoring.

---
*PR created automatically by Jules for task [7462677781009341253](https://jules.google.com/task/7462677781009341253) started by @celsowm*