### PR TITLE
Fix performance bottleneck in table-aware text edits by implementing structural sharing

### DIFF
--- a/src/app/controllers/useEditorTableOperations.ts
+++ b/src/app/controllers/useEditorTableOperations.ts
@@ -1,6 +1,4 @@
-import {
-  cloneBlock,
-} from "../../core/cloneState.js";
+import { cloneBlock } from "../../core/cloneState.js";
 import {
   createEditorDocument,
   createEditorParagraph,
@@ -51,10 +49,16 @@ export interface EditorTableOperationsDeps {
 }
 
 export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
-  const getTargetBlocks = (state: EditorState, zone: EditorEditingZone): EditorBlockNode[] => {
+  const getTargetBlocks = (
+    state: EditorState,
+    zone: EditorEditingZone,
+  ): EditorBlockNode[] => {
     const activeSectionIndex = getActiveSectionIndex(state);
-    const hasSections = state.document.sections && state.document.sections.length > 0;
-    const section = hasSections ? state.document.sections![activeSectionIndex] : null;
+    const hasSections =
+      state.document.sections && state.document.sections.length > 0;
+    const section = hasSections
+      ? state.document.sections![activeSectionIndex]
+      : null;
 
     if (section) {
       if (zone === "header") return section.header || [];
@@ -68,8 +72,16 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     current: EditorState,
   ): EditorState["selection"] | null => {
     const sel = current.selection;
-    const anchorLocation = findParagraphTableLocation(current.document, sel.anchor.paragraphId, getActiveSectionIndex(current));
-    const focusLocation = findParagraphTableLocation(current.document, sel.focus.paragraphId, getActiveSectionIndex(current));
+    const anchorLocation = findParagraphTableLocation(
+      current.document,
+      sel.anchor.paragraphId,
+      getActiveSectionIndex(current),
+    );
+    const focusLocation = findParagraphTableLocation(
+      current.document,
+      sel.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (
       !anchorLocation ||
       !focusLocation ||
@@ -78,15 +90,31 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       (anchorLocation.rowIndex === focusLocation.rowIndex &&
         anchorLocation.cellIndex === focusLocation.cellIndex)
     ) {
-      deps.logger?.debug(`resolveTableCellRangeSelection: no expansion (anchor=${sel.anchor.paragraphId} focus=${sel.focus.paragraphId})`);
+      deps.logger?.debug(
+        `resolveTableCellRangeSelection: no expansion (anchor=${sel.anchor.paragraphId} focus=${sel.focus.paragraphId})`,
+      );
       return null;
     }
 
-    const rangeStartRow = Math.min(anchorLocation.rowIndex, focusLocation.rowIndex);
-    const rangeEndRow = Math.max(anchorLocation.rowIndex, focusLocation.rowIndex);
-    const rangeStartCell = Math.min(anchorLocation.cellIndex, focusLocation.cellIndex);
-    const rangeEndCell = Math.max(anchorLocation.cellIndex, focusLocation.cellIndex);
-    deps.logger?.info(`resolveTableCellRangeSelection: expanding r${anchorLocation.rowIndex}:c${anchorLocation.cellIndex}→r${focusLocation.rowIndex}:c${focusLocation.cellIndex} (anchor=${sel.anchor.paragraphId} focus=${sel.focus.paragraphId}) range=[rows ${rangeStartRow}..${rangeEndRow}, cells ${rangeStartCell}..${rangeEndCell}]`);
+    const rangeStartRow = Math.min(
+      anchorLocation.rowIndex,
+      focusLocation.rowIndex,
+    );
+    const rangeEndRow = Math.max(
+      anchorLocation.rowIndex,
+      focusLocation.rowIndex,
+    );
+    const rangeStartCell = Math.min(
+      anchorLocation.cellIndex,
+      focusLocation.cellIndex,
+    );
+    const rangeEndCell = Math.max(
+      anchorLocation.cellIndex,
+      focusLocation.cellIndex,
+    );
+    deps.logger?.info(
+      `resolveTableCellRangeSelection: expanding r${anchorLocation.rowIndex}:c${anchorLocation.cellIndex}→r${focusLocation.rowIndex}:c${focusLocation.cellIndex} (anchor=${sel.anchor.paragraphId} focus=${sel.focus.paragraphId}) range=[rows ${rangeStartRow}..${rangeEndRow}, cells ${rangeStartCell}..${rangeEndCell}]`,
+    );
 
     const blocks = getTargetBlocks(current, anchorLocation.zone);
     const tableBlock = blocks[anchorLocation.blockIndex];
@@ -97,11 +125,13 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     const tableLayout = buildTableCellLayout(tableBlock);
     const anchorCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === anchorLocation.rowIndex && entry.cellIndex === anchorLocation.cellIndex,
+        entry.rowIndex === anchorLocation.rowIndex &&
+        entry.cellIndex === anchorLocation.cellIndex,
     );
     const focusCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === focusLocation.rowIndex && entry.cellIndex === focusLocation.cellIndex,
+        entry.rowIndex === focusLocation.rowIndex &&
+        entry.cellIndex === focusLocation.cellIndex,
     );
     if (!anchorCell || !focusCell) {
       return null;
@@ -120,12 +150,20 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return 0;
     };
 
-    const startLocation = compareCellLocations(anchorCell, focusCell) <= 0 ? anchorLocation : focusLocation;
-    const endLocation = compareCellLocations(anchorCell, focusCell) <= 0 ? focusLocation : anchorLocation;
+    const startLocation =
+      compareCellLocations(anchorCell, focusCell) <= 0
+        ? anchorLocation
+        : focusLocation;
+    const endLocation =
+      compareCellLocations(anchorCell, focusCell) <= 0
+        ? focusLocation
+        : anchorLocation;
 
     const startParagraph =
-      tableBlock.rows[startLocation.rowIndex]?.cells[startLocation.cellIndex]?.blocks[0];
-    const endCell = tableBlock.rows[endLocation.rowIndex]?.cells[endLocation.cellIndex];
+      tableBlock.rows[startLocation.rowIndex]?.cells[startLocation.cellIndex]
+        ?.blocks[0];
+    const endCell =
+      tableBlock.rows[endLocation.rowIndex]?.cells[endLocation.cellIndex];
     const endParagraph = endCell?.blocks[endCell.blocks.length - 1];
     if (!startParagraph || !endParagraph) {
       return null;
@@ -133,13 +171,20 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
     return {
       anchor: paragraphOffsetToPosition(startParagraph, 0),
-      focus: paragraphOffsetToPosition(endParagraph, getParagraphText(endParagraph).length),
+      focus: paragraphOffsetToPosition(
+        endParagraph,
+        getParagraphText(endParagraph).length,
+      ),
     };
   };
 
   const resolveSelectedTableCells = (
     current: EditorState,
-  ): { blockIndex: number; cells: TableCellLayoutEntry[]; zone: EditorEditingZone } | null => {
+  ): {
+    blockIndex: number;
+    cells: TableCellLayoutEntry[];
+    zone: EditorEditingZone;
+  } | null => {
     const sel = current.selection;
     const anchorLocation = findParagraphTableLocation(
       current.document,
@@ -169,22 +214,30 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     const tableLayout = buildTableCellLayout(tableBlock);
     const anchorCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === anchorLocation.rowIndex && entry.cellIndex === anchorLocation.cellIndex,
+        entry.rowIndex === anchorLocation.rowIndex &&
+        entry.cellIndex === anchorLocation.cellIndex,
     );
     const focusCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === focusLocation.rowIndex && entry.cellIndex === focusLocation.cellIndex,
+        entry.rowIndex === focusLocation.rowIndex &&
+        entry.cellIndex === focusLocation.cellIndex,
     );
     if (!anchorCell || !focusCell) {
       return null;
     }
 
-    const startRow = Math.min(anchorCell.visualRowIndex, focusCell.visualRowIndex);
+    const startRow = Math.min(
+      anchorCell.visualRowIndex,
+      focusCell.visualRowIndex,
+    );
     const endRow = Math.max(
       anchorCell.visualRowIndex + anchorCell.rowSpan - 1,
       focusCell.visualRowIndex + focusCell.rowSpan - 1,
     );
-    const startCol = Math.min(anchorCell.visualColumnIndex, focusCell.visualColumnIndex);
+    const startCol = Math.min(
+      anchorCell.visualColumnIndex,
+      focusCell.visualColumnIndex,
+    );
     const endCol = Math.max(
       anchorCell.visualColumnIndex + anchorCell.colSpan - 1,
       focusCell.visualColumnIndex + focusCell.colSpan - 1,
@@ -199,7 +252,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       );
     });
 
-    return { blockIndex: anchorLocation.blockIndex, cells, zone: anchorLocation.zone };
+    return {
+      blockIndex: anchorLocation.blockIndex,
+      cells,
+      zone: anchorLocation.zone,
+    };
   };
 
   const resolveHorizontalTableCellRange = (
@@ -211,8 +268,16 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     endCellIndex: number;
     zone: EditorEditingZone;
   } | null => {
-    const anchorLocation = findParagraphTableLocation(current.document, current.selection.anchor.paragraphId, getActiveSectionIndex(current));
-    const focusLocation = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const anchorLocation = findParagraphTableLocation(
+      current.document,
+      current.selection.anchor.paragraphId,
+      getActiveSectionIndex(current),
+    );
+    const focusLocation = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (
       !anchorLocation ||
       !focusLocation ||
@@ -231,11 +296,13 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     const tableLayout = buildTableCellLayout(tableBlock);
     const anchorCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === anchorLocation.rowIndex && entry.cellIndex === anchorLocation.cellIndex,
+        entry.rowIndex === anchorLocation.rowIndex &&
+        entry.cellIndex === anchorLocation.cellIndex,
     );
     const focusCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === focusLocation.rowIndex && entry.cellIndex === focusLocation.cellIndex,
+        entry.rowIndex === focusLocation.rowIndex &&
+        entry.cellIndex === focusLocation.cellIndex,
     );
     if (!anchorCell || !focusCell) {
       return null;
@@ -254,8 +321,14 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return 0;
     };
 
-    const startLocation = compareCellLocations(anchorCell, focusCell) <= 0 ? anchorLocation : focusLocation;
-    const endLocation = compareCellLocations(anchorCell, focusCell) <= 0 ? focusLocation : anchorLocation;
+    const startLocation =
+      compareCellLocations(anchorCell, focusCell) <= 0
+        ? anchorLocation
+        : focusLocation;
+    const endLocation =
+      compareCellLocations(anchorCell, focusCell) <= 0
+        ? focusLocation
+        : anchorLocation;
 
     if (anchorCell.visualRowIndex !== focusCell.visualRowIndex) {
       return null;
@@ -280,7 +353,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const canSplitSelectedTableCell = (current: EditorState): boolean => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return false;
     }
@@ -304,8 +381,16 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     cellIndex: number;
     zone: EditorEditingZone;
   } | null => {
-    const anchorLocation = findParagraphTableLocation(current.document, current.selection.anchor.paragraphId, getActiveSectionIndex(current));
-    const focusLocation = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const anchorLocation = findParagraphTableLocation(
+      current.document,
+      current.selection.anchor.paragraphId,
+      getActiveSectionIndex(current),
+    );
+    const focusLocation = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (
       !anchorLocation ||
       !focusLocation ||
@@ -325,18 +410,26 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     const tableLayout = buildTableCellLayout(tableBlock);
     const anchorCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === anchorLocation.rowIndex && entry.cellIndex === anchorLocation.cellIndex,
+        entry.rowIndex === anchorLocation.rowIndex &&
+        entry.cellIndex === anchorLocation.cellIndex,
     );
     const focusCell = tableLayout.find(
       (entry) =>
-        entry.rowIndex === focusLocation.rowIndex && entry.cellIndex === focusLocation.cellIndex,
+        entry.rowIndex === focusLocation.rowIndex &&
+        entry.cellIndex === focusLocation.cellIndex,
     );
     if (!anchorCell || !focusCell) {
       return null;
     }
 
-    const startRowIndex = Math.min(anchorCell.visualRowIndex, focusCell.visualRowIndex);
-    const endRowIndex = Math.max(anchorCell.visualRowIndex, focusCell.visualRowIndex);
+    const startRowIndex = Math.min(
+      anchorCell.visualRowIndex,
+      focusCell.visualRowIndex,
+    );
+    const endRowIndex = Math.max(
+      anchorCell.visualRowIndex,
+      focusCell.visualRowIndex,
+    );
     if (startRowIndex === endRowIndex) {
       return null;
     }
@@ -362,7 +455,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return false;
     }
 
-    for (let rowIndex = range.startRowIndex; rowIndex <= range.endRowIndex; rowIndex += 1) {
+    for (
+      let rowIndex = range.startRowIndex;
+      rowIndex <= range.endRowIndex;
+      rowIndex += 1
+    ) {
       const cell = tableBlock.rows[rowIndex]?.cells[range.cellIndex];
       if (!cell || cell.vMerge === "continue" || cell.blocks.length !== 1) {
         return false;
@@ -373,11 +470,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const canMergeSelectedTable = (current: EditorState): boolean => {
-    return canMergeSelectedTableCells(current) || canMergeSelectedTableRows(current);
+    return (
+      canMergeSelectedTableCells(current) || canMergeSelectedTableRows(current)
+    );
   };
 
-  const canSplitSelectedTableCellVertically = (current: EditorState): boolean => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+  const canSplitSelectedTableCellVertically = (
+    current: EditorState,
+  ): boolean => {
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return false;
     }
@@ -393,7 +498,10 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const canSplitSelectedTable = (current: EditorState): boolean => {
-    return canSplitSelectedTableCell(current) || canSplitSelectedTableCellVertically(current);
+    return (
+      canSplitSelectedTableCell(current) ||
+      canSplitSelectedTableCellVertically(current)
+    );
   };
 
   const updateBlocksInCurrentSection = (
@@ -402,7 +510,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     zone: EditorEditingZone = "main",
   ): EditorState => {
     const activeSectionIndex = getActiveSectionIndex(current);
-    const hasSections = current.document.sections && current.document.sections.length > 0;
+    const hasSections =
+      current.document.sections && current.document.sections.length > 0;
 
     if (hasSections) {
       const nextSections = [...current.document.sections!];
@@ -438,7 +547,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, range.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, range.zone)];
+    targetBlocks[range.blockIndex] = cloneBlock(targetBlocks[range.blockIndex]);
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -449,15 +559,23 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const selectedCells = row.cells.slice(range.startCellIndex, range.endCellIndex + 1);
+    const selectedCells = row.cells.slice(
+      range.startCellIndex,
+      range.endCellIndex + 1,
+    );
     if (selectedCells.length < 2) {
       return current;
     }
 
     const mergedCell = {
       ...selectedCells[0]!,
-      colSpan: selectedCells.reduce((sum, cell) => sum + Math.max(1, cell.colSpan ?? 1), 0),
-      blocks: selectedCells.flatMap((cell: any) => cell.blocks.map((paragraph: any) => cloneBlock(paragraph))) as EditorParagraphNode[],
+      colSpan: selectedCells.reduce(
+        (sum, cell) => sum + Math.max(1, cell.colSpan ?? 1),
+        0,
+      ),
+      blocks: selectedCells.flatMap((cell: any) =>
+        cell.blocks.map((paragraph: any) => cloneBlock(paragraph)),
+      ) as EditorParagraphNode[],
     };
 
     row.cells.splice(range.startCellIndex, selectedCells.length, mergedCell);
@@ -467,7 +585,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, range.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      range.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -483,17 +605,29 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, range.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, range.zone)];
+    targetBlocks[range.blockIndex] = cloneBlock(targetBlocks[range.blockIndex]);
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
 
-    const selectedCells: Array<NonNullable<typeof tableBlock.rows[number]["cells"][number]>> = [];
-    for (let rowIndex = range.startRowIndex; rowIndex <= range.endRowIndex; rowIndex += 1) {
+    const selectedCells: Array<
+      NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
+    > = [];
+    for (
+      let rowIndex = range.startRowIndex;
+      rowIndex <= range.endRowIndex;
+      rowIndex += 1
+    ) {
       const row = tableBlock.rows[rowIndex];
       const cell = row?.cells[range.cellIndex];
-      if (!row || !cell || cell.vMerge === "continue" || cell.blocks.length !== 1) {
+      if (
+        !row ||
+        !cell ||
+        cell.vMerge === "continue" ||
+        cell.blocks.length !== 1
+      ) {
         return current;
       }
       selectedCells.push(cell);
@@ -504,7 +638,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     }
 
     const mergedColSpan = Math.max(1, selectedCells[0]!.colSpan ?? 1);
-    if (!selectedCells.every((cell) => Math.max(1, cell.colSpan ?? 1) === mergedColSpan)) {
+    if (
+      !selectedCells.every(
+        (cell) => Math.max(1, cell.colSpan ?? 1) === mergedColSpan,
+      )
+    ) {
       return current;
     }
 
@@ -518,8 +656,15 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     };
     tableBlock.rows[range.startRowIndex]!.cells[range.cellIndex] = mergedCell;
 
-    for (let rowIndex = range.startRowIndex + 1; rowIndex <= range.endRowIndex; rowIndex += 1) {
-      const placeholder = createEditorTableCell([createEditorParagraph("")], mergedColSpan);
+    for (
+      let rowIndex = range.startRowIndex + 1;
+      rowIndex <= range.endRowIndex;
+      rowIndex += 1
+    ) {
+      const placeholder = createEditorTableCell(
+        [createEditorParagraph("")],
+        mergedColSpan,
+      );
       placeholder.blocks = [];
       placeholder.vMerge = "continue";
       tableBlock.rows[rowIndex]!.cells[range.cellIndex] = placeholder;
@@ -530,7 +675,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, range.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      range.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -552,13 +701,22 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     return current;
   };
 
-  const splitSelectedTableCellVertically = (current: EditorState): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+  const splitSelectedTableCellVertically = (
+    current: EditorState,
+  ): EditorState => {
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -580,7 +738,10 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       if (!row) {
         break;
       }
-      const replacement = createEditorTableCell([createEditorParagraph("")], preservedColSpan);
+      const replacement = createEditorTableCell(
+        [createEditorParagraph("")],
+        preservedColSpan,
+      );
       row.cells[location.cellIndex] = replacement;
     }
 
@@ -589,7 +750,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      location.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -600,12 +765,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const splitSelectedTableCell = (current: EditorState): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -622,9 +794,13 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       {
         ...cell,
         colSpan: 1,
-        blocks: cell.blocks.map((paragraph: any) => cloneBlock(paragraph)) as EditorParagraphNode[],
+        blocks: cell.blocks.map((paragraph: any) =>
+          cloneBlock(paragraph),
+        ) as EditorParagraphNode[],
       },
-      ...Array.from({ length: span - 1 }, () => createEditorTableCell([createEditorParagraph("")])),
+      ...Array.from({ length: span - 1 }, () =>
+        createEditorTableCell([createEditorParagraph("")]),
+      ),
     ];
 
     row.cells.splice(location.cellIndex, 1, ...nextCells);
@@ -634,7 +810,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      location.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -678,7 +858,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     return null;
   };
 
-  const findFirstNavigableParagraphInTable = (table: EditorTableNode): EditorParagraphNode | null => {
+  const findFirstNavigableParagraphInTable = (
+    table: EditorTableNode,
+  ): EditorParagraphNode | null => {
     for (const row of table.rows) {
       for (const cell of row.cells) {
         if (cell.vMerge === "continue") {
@@ -695,7 +877,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const canEditSelectedTableRow = (current: EditorState): boolean => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return false;
     }
@@ -706,7 +892,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const canEditSelectedTableColumn = (current: EditorState): boolean => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return false;
     }
@@ -720,13 +910,23 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     return getTableVisualWidth(block) > 1;
   };
 
-  const insertSelectedTableRow = (current: EditorState, direction: -1 | 1): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+  const insertSelectedTableRow = (
+    current: EditorState,
+    direction: -1 | 1,
+  ): EditorState => {
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -739,11 +939,17 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
     const insertIndex = Math.max(
       0,
-      Math.min(tableBlock.rows.length, location.rowIndex + (direction > 0 ? 1 : 0)),
+      Math.min(
+        tableBlock.rows.length,
+        location.rowIndex + (direction > 0 ? 1 : 0),
+      ),
     );
 
     const hasVerticalSpansInTable = tableBlock.rows.some((row) =>
-      row.cells.some((cell) => Math.max(1, cell.rowSpan ?? 1) > 1 || cell.vMerge !== undefined),
+      row.cells.some(
+        (cell) =>
+          Math.max(1, cell.rowSpan ?? 1) > 1 || cell.vMerge !== undefined,
+      ),
     );
 
     let blankRow: EditorTableRowNode;
@@ -751,13 +957,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       const tableLayout = buildTableCellLayout(tableBlock);
       const selectedEntry = tableLayout.find(
         (layoutEntry) =>
-          layoutEntry.rowIndex === location.rowIndex && layoutEntry.cellIndex === location.cellIndex,
+          layoutEntry.rowIndex === location.rowIndex &&
+          layoutEntry.cellIndex === location.cellIndex,
       );
-      const sourceEntries = tableLayout.filter((layoutEntry) => layoutEntry.rowIndex === location.rowIndex);
+      const sourceEntries = tableLayout.filter(
+        (layoutEntry) => layoutEntry.rowIndex === location.rowIndex,
+      );
       const templateEntries =
         sourceEntries.length > 0
           ? sourceEntries
-          : tableLayout.filter((layoutEntry) => layoutEntry.rowIndex === Math.max(0, location.rowIndex - 1));
+          : tableLayout.filter(
+              (layoutEntry) =>
+                layoutEntry.rowIndex === Math.max(0, location.rowIndex - 1),
+            );
       blankRow = createEditorTableRow(
         templateEntries.map((layoutEntry) => {
           const spanningEntry = tableLayout.find(
@@ -767,7 +979,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
               candidate.visualRowIndex + candidate.rowSpan > insertIndex,
           );
           if (spanningEntry) {
-            spanningEntry.cell.rowSpan = Math.max(1, spanningEntry.cell.rowSpan ?? 1) + 1;
+            spanningEntry.cell.rowSpan =
+              Math.max(1, spanningEntry.cell.rowSpan ?? 1) + 1;
             spanningEntry.cell.vMerge = "restart";
             const placeholder = createEditorTableCell(
               [createEditorParagraph("")],
@@ -778,22 +991,36 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
             return placeholder;
           }
 
-          return createEditorTableCell([createEditorParagraph("")], layoutEntry.colSpan);
+          return createEditorTableCell(
+            [createEditorParagraph("")],
+            layoutEntry.colSpan,
+          );
         }),
       );
       tableBlock.rows.splice(insertIndex, 0, blankRow);
 
-      const targetVisualColumn = selectedEntry?.visualColumnIndex ?? location.cellIndex;
+      const targetVisualColumn =
+        selectedEntry?.visualColumnIndex ?? location.cellIndex;
       const targetCell = findCellAtVisualColumn(blankRow, targetVisualColumn);
       const nextParagraph =
         targetCell?.blocks[0] ??
-        blankRow.cells.find((cell) => cell.vMerge !== "continue" && cell.blocks[0])?.blocks[0] ??
+        blankRow.cells.find(
+          (cell) => cell.vMerge !== "continue" && cell.blocks[0],
+        )?.blocks[0] ??
         findFirstNavigableParagraphInTable(tableBlock);
       if (!nextParagraph) {
-        return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+        return updateBlocksInCurrentSection(
+          current,
+          targetBlocks,
+          location.zone,
+        );
       }
 
-      const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+      const nextState = updateBlocksInCurrentSection(
+        current,
+        targetBlocks,
+        location.zone,
+      );
       return {
         ...nextState,
         selection: {
@@ -812,16 +1039,27 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       );
       tableBlock.rows.splice(insertIndex, 0, blankRow);
 
-      const targetCell = blankRow.cells[Math.min(location.cellIndex, blankRow.cells.length - 1)];
+      const targetCell =
+        blankRow.cells[Math.min(location.cellIndex, blankRow.cells.length - 1)];
       const nextParagraph =
         targetCell?.blocks[0] ??
-        blankRow.cells.find((cell) => cell.vMerge !== "continue" && cell.blocks[0])?.blocks[0] ??
+        blankRow.cells.find(
+          (cell) => cell.vMerge !== "continue" && cell.blocks[0],
+        )?.blocks[0] ??
         findFirstNavigableParagraphInTable(tableBlock);
       if (!nextParagraph) {
-        return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+        return updateBlocksInCurrentSection(
+          current,
+          targetBlocks,
+          location.zone,
+        );
       }
 
-      const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+      const nextState = updateBlocksInCurrentSection(
+        current,
+        targetBlocks,
+        location.zone,
+      );
       return {
         ...nextState,
         selection: {
@@ -833,12 +1071,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const deleteSelectedTableRow = (current: EditorState): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -854,14 +1099,18 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     }
 
     const blockedByRestartCell = rowToDelete.cells.some(
-      (cell) => cell.vMerge !== "continue" && Math.max(1, cell.rowSpan ?? 1) > 1,
+      (cell) =>
+        cell.vMerge !== "continue" && Math.max(1, cell.rowSpan ?? 1) > 1,
     );
     if (blockedByRestartCell) {
       return current;
     }
 
     const hasVerticalSpansInTable = tableBlock.rows.some((row) =>
-      row.cells.some((cell) => Math.max(1, cell.rowSpan ?? 1) > 1 || cell.vMerge !== undefined),
+      row.cells.some(
+        (cell) =>
+          Math.max(1, cell.rowSpan ?? 1) > 1 || cell.vMerge !== undefined,
+      ),
     );
 
     const selectedEntry = hasVerticalSpansInTable
@@ -892,7 +1141,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
     tableBlock.rows.splice(location.rowIndex, 1);
 
-    const nextRow = tableBlock.rows[Math.min(location.rowIndex, tableBlock.rows.length - 1)];
+    const nextRow =
+      tableBlock.rows[Math.min(location.rowIndex, tableBlock.rows.length - 1)];
     const targetCell = nextRow
       ? findCellAtVisualColumn(
           nextRow,
@@ -902,12 +1152,17 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
           ),
         )
       : null;
-    const nextParagraph = targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
+    const nextParagraph =
+      targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
     if (!nextParagraph) {
       return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      location.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -917,25 +1172,38 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     };
   };
 
-  const insertSelectedTableColumn = (current: EditorState, direction: -1 | 1): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+  const insertSelectedTableColumn = (
+    current: EditorState,
+    direction: -1 | 1,
+  ): EditorState => {
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
 
-    const hasHorizontalSpansInTable = tableBlock.rows.some((row) => row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1));
+    const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
+      row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
+    );
 
     if (hasHorizontalSpansInTable) {
       const tableLayout = buildTableCellLayout(tableBlock);
       const selectedEntry = tableLayout.find(
         (entry) =>
-          entry.rowIndex === location.rowIndex && entry.cellIndex === location.cellIndex,
+          entry.rowIndex === location.rowIndex &&
+          entry.cellIndex === location.cellIndex,
       );
       const insertVisualColumn =
         (selectedEntry?.visualColumnIndex ?? location.cellIndex) +
@@ -953,7 +1221,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
             inserted = true;
           }
 
-          if (!inserted && visualCursor < insertVisualColumn && insertVisualColumn < visualCursor + span) {
+          if (
+            !inserted &&
+            visualCursor < insertVisualColumn &&
+            insertVisualColumn < visualCursor + span
+          ) {
             nextCells.push({
               ...cell,
               colSpan: span + 1,
@@ -974,13 +1246,24 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       }
 
       const targetRow = tableBlock.rows[location.rowIndex];
-      const targetCell = targetRow ? findCellAtVisualColumn(targetRow, insertVisualColumn) : null;
-      const nextParagraph = targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
+      const targetCell = targetRow
+        ? findCellAtVisualColumn(targetRow, insertVisualColumn)
+        : null;
+      const nextParagraph =
+        targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
       if (!nextParagraph) {
-        return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+        return updateBlocksInCurrentSection(
+          current,
+          targetBlocks,
+          location.zone,
+        );
       }
 
-      const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+      const nextState = updateBlocksInCurrentSection(
+        current,
+        targetBlocks,
+        location.zone,
+      );
       return {
         ...nextState,
         selection: {
@@ -992,7 +1275,10 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
     const insertIndex = Math.max(
       0,
-      Math.min(tableBlock.rows[0]?.cells.length ?? 0, location.cellIndex + (direction > 0 ? 1 : 0)),
+      Math.min(
+        tableBlock.rows[0]?.cells.length ?? 0,
+        location.cellIndex + (direction > 0 ? 1 : 0),
+      ),
     );
 
     for (const row of tableBlock.rows) {
@@ -1005,12 +1291,17 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
     const targetRow = tableBlock.rows[location.rowIndex];
     const targetCell = targetRow?.cells[insertIndex];
-    const nextParagraph = targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
+    const nextParagraph =
+      targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
     if (!nextParagraph) {
       return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      location.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -1021,12 +1312,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
   };
 
   const deleteSelectedTableColumn = (current: EditorState): EditorState => {
-    const location = findParagraphTableLocation(current.document, current.selection.focus.paragraphId, getActiveSectionIndex(current));
+    const location = findParagraphTableLocation(
+      current.document,
+      current.selection.focus.paragraphId,
+      getActiveSectionIndex(current),
+    );
     if (!location) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const targetBlocks = [...getTargetBlocks(current, location.zone)];
+    targetBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -1036,15 +1334,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const hasHorizontalSpansInTable = tableBlock.rows.some((row) => row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1));
+    const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
+      row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
+    );
 
     if (hasHorizontalSpansInTable) {
       const tableLayout = buildTableCellLayout(tableBlock);
       const selectedEntry = tableLayout.find(
         (entry) =>
-          entry.rowIndex === location.rowIndex && entry.cellIndex === location.cellIndex,
+          entry.rowIndex === location.rowIndex &&
+          entry.cellIndex === location.cellIndex,
       );
-      const deleteVisualColumn = selectedEntry?.visualColumnIndex ?? location.cellIndex;
+      const deleteVisualColumn =
+        selectedEntry?.visualColumnIndex ?? location.cellIndex;
 
       for (const row of tableBlock.rows) {
         const nextCells: EditorTableCellNode[] = [];
@@ -1052,7 +1354,10 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
 
         for (const cell of row.cells) {
           const span = Math.max(1, cell.colSpan ?? 1);
-          if (deleteVisualColumn >= visualCursor && deleteVisualColumn < visualCursor + span) {
+          if (
+            deleteVisualColumn >= visualCursor &&
+            deleteVisualColumn < visualCursor + span
+          ) {
             if (span > 1) {
               nextCells.push({
                 ...cell,
@@ -1074,14 +1379,26 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
         targetRow &&
         findCellAtVisualColumn(
           targetRow,
-          Math.min(deleteVisualColumn, Math.max(0, getRowVisualWidth(targetRow) - 1)),
+          Math.min(
+            deleteVisualColumn,
+            Math.max(0, getRowVisualWidth(targetRow) - 1),
+          ),
         );
-      const nextParagraph = targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
+      const nextParagraph =
+        targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
       if (!nextParagraph) {
-        return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+        return updateBlocksInCurrentSection(
+          current,
+          targetBlocks,
+          location.zone,
+        );
       }
 
-      const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+      const nextState = updateBlocksInCurrentSection(
+        current,
+        targetBlocks,
+        location.zone,
+      );
       return {
         ...nextState,
         selection: {
@@ -1100,13 +1417,21 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     }
 
     const targetRow = tableBlock.rows[location.rowIndex];
-    const targetCell = targetRow?.cells[Math.min(location.cellIndex, targetRow.cells.length - 1)];
-    const nextParagraph = targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
+    const targetCell =
+      targetRow?.cells[
+        Math.min(location.cellIndex, targetRow.cells.length - 1)
+      ];
+    const nextParagraph =
+      targetCell?.blocks[0] ?? findFirstNavigableParagraphInTable(tableBlock);
     if (!nextParagraph) {
       return updateBlocksInCurrentSection(current, targetBlocks, location.zone);
     }
 
-    const nextState = updateBlocksInCurrentSection(current, targetBlocks, location.zone);
+    const nextState = updateBlocksInCurrentSection(
+      current,
+      targetBlocks,
+      location.zone,
+    );
     return {
       ...nextState,
       selection: {
@@ -1136,7 +1461,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
         }
 
         const cells = block.rows.flatMap((row) =>
-          row.cells.filter((cell) => cell.vMerge !== "continue" && cell.blocks.length > 0),
+          row.cells.filter(
+            (cell) => cell.vMerge !== "continue" && cell.blocks.length > 0,
+          ),
         );
         const currentCellIndex = cells.findIndex((cell) =>
           cell.blocks.some((paragraph) => paragraph.id === paragraphId),
@@ -1171,13 +1498,20 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       current.selection.focus.paragraphId,
       getActiveSectionIndex(current),
     );
-    if (!location || current.selection.anchor.paragraphId !== current.selection.focus.paragraphId) {
+    if (
+      !location ||
+      current.selection.anchor.paragraphId !==
+        current.selection.focus.paragraphId
+    ) {
       return edit(current);
     }
 
     const activeSectionIndex = getActiveSectionIndex(current);
-    const hasSections = current.document.sections && current.document.sections.length > 0;
-    const section = hasSections ? current.document.sections![activeSectionIndex] : null;
+    const hasSections =
+      current.document.sections && current.document.sections.length > 0;
+    const section = hasSections
+      ? current.document.sections![activeSectionIndex]
+      : null;
 
     const zone = location.zone;
     let targetBlocks: EditorBlockNode[] = [];
@@ -1189,13 +1523,17 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       targetBlocks = current.document.blocks;
     }
 
-    const nextBlocks = targetBlocks.map(cloneBlock);
+    const nextBlocks = [...targetBlocks];
+    nextBlocks[location.blockIndex] = cloneBlock(
+      targetBlocks[location.blockIndex],
+    );
     const tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return edit(current);
     }
 
-    const targetCell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
+    const targetCell =
+      tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     if (!targetCell) {
       return edit(current);
     }
@@ -1222,7 +1560,11 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       (block): block is EditorParagraphNode => block.type === "paragraph",
     );
 
-    targetCell.blocks.splice(0, targetCell.blocks.length, ...replacementParagraphs);
+    targetCell.blocks.splice(
+      0,
+      targetCell.blocks.length,
+      ...replacementParagraphs,
+    );
 
     const nextState = updateBlocksInCurrentSection(current, nextBlocks, zone);
     return {
@@ -1231,13 +1573,18 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     };
   };
 
-  const withExpandedTableCellSelection = (current: EditorState): EditorState => {
+  const withExpandedTableCellSelection = (
+    current: EditorState,
+  ): EditorState => {
     const expandedSelection = resolveTableCellRangeSelection(current);
     if (!expandedSelection) {
       return current;
     }
 
-    return deps.applySelectionToStatePreservingStructure(current, expandedSelection);
+    return deps.applySelectionToStatePreservingStructure(
+      current,
+      expandedSelection,
+    );
   };
 
   const applySelectionAwareCommand = (
@@ -1301,7 +1648,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       const resultParagraphs = getParagraphs(tempResult);
 
       // 4. Distribute paragraphs back to cells
-      const targetBlocks = getTargetBlocks(current, zone).map(cloneBlock);
+      const targetBlocks = [...getTargetBlocks(current, zone)];
+      targetBlocks[blockIndex] = cloneBlock(targetBlocks[blockIndex]);
       const tableBlock = targetBlocks[blockIndex] as EditorTableNode;
       if (!tableBlock) {
         return current;
@@ -1314,7 +1662,8 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
         const cellParagraphs = resultParagraphs.slice(pIdx, pIdx + count);
         pIdx += count;
 
-        const targetCell = tableBlock.rows[entry.rowIndex]?.cells[entry.cellIndex];
+        const targetCell =
+          tableBlock.rows[entry.rowIndex]?.cells[entry.cellIndex];
         if (targetCell) {
           targetCell.blocks = cellParagraphs;
         }
@@ -1324,19 +1673,26 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     });
   };
 
-  const applySelectionAwareTextCommand = (command: (current: EditorState) => EditorState) => {
+  const applySelectionAwareTextCommand = (
+    command: (current: EditorState) => EditorState,
+  ) => {
     applySelectionAwareCommand(command, "applySelectionAwareTextCommand");
   };
 
-  const applySelectionAwareParagraphCommand = (command: (current: EditorState) => EditorState) => {
+  const applySelectionAwareParagraphCommand = (
+    command: (current: EditorState) => EditorState,
+  ) => {
     applySelectionAwareCommand(command, "applySelectionAwareParagraphCommand");
   };
 
   const insertTableCommand = (rows: number, cols: number) => {
     deps.logger?.info(`insertTableCommand: ${rows}x${cols}`);
-    deps.applyTransactionalState((current) => insertTableAtSelection(current, rows, cols), {
-      mergeKey: "insertTable",
-    });
+    deps.applyTransactionalState(
+      (current) => insertTableAtSelection(current, rows, cols),
+      {
+        mergeKey: "insertTable",
+      },
+    );
     deps.focusInput();
   };
 

--- a/src/core/commands/utils.ts
+++ b/src/core/commands/utils.ts
@@ -1,7 +1,39 @@
-import type { EditorBlockNode, EditorDocument, EditorParagraphListStyle, EditorParagraphStyle, EditorParagraphNode, EditorPosition, EditorSelection, EditorState, EditorTextRun, EditorTextStyle, EditorImageRunData, EditorSection, EditorTableCellNode } from "../model.js";
-import { getParagraphLength, getParagraphs, paragraphOffsetToPosition, positionToParagraphOffset, getActiveSectionIndex, getActiveZone, resolveImageSrc } from "../model.js";
-import { createEditorDocument, createEditorParagraphFromRuns, createEditorStyledRun } from "../editorState.js";
-import { clampPosition, createCollapsedSelection, findParagraphIndex, isSelectionCollapsed, normalizeSelection } from "../selection.js";
+import type {
+  EditorBlockNode,
+  EditorDocument,
+  EditorParagraphListStyle,
+  EditorParagraphStyle,
+  EditorParagraphNode,
+  EditorPosition,
+  EditorSelection,
+  EditorState,
+  EditorTextRun,
+  EditorTextStyle,
+  EditorImageRunData,
+  EditorSection,
+  EditorTableCellNode,
+} from "../model.js";
+import {
+  getParagraphLength,
+  getParagraphs,
+  paragraphOffsetToPosition,
+  positionToParagraphOffset,
+  getActiveSectionIndex,
+  getActiveZone,
+  resolveImageSrc,
+} from "../model.js";
+import {
+  createEditorDocument,
+  createEditorParagraphFromRuns,
+  createEditorStyledRun,
+} from "../editorState.js";
+import {
+  clampPosition,
+  createCollapsedSelection,
+  findParagraphIndex,
+  isSelectionCollapsed,
+  normalizeSelection,
+} from "../selection.js";
 import { deleteBackward } from "./text.js";
 import { setSelection } from "./selection.js";
 
@@ -13,7 +45,12 @@ export type ToggleableTextStyleKey =
   | "superscript"
   | "subscript";
 
-export type ValueTextStyleKey = "fontFamily" | "fontSize" | "color" | "highlight" | "link";
+export type ValueTextStyleKey =
+  | "fontFamily"
+  | "fontSize"
+  | "color"
+  | "highlight"
+  | "link";
 
 export type ValueParagraphStyleKey =
   | "styleId"
@@ -36,11 +73,16 @@ export type ValueParagraphStyleKey =
 
 export type ParagraphListKind = EditorParagraphListStyle["kind"];
 
-export function cloneStyle(style?: EditorTextStyle): EditorTextStyle | undefined {
+export function cloneStyle(
+  style?: EditorTextStyle,
+): EditorTextStyle | undefined {
   return style ? { ...style } : undefined;
 }
 
-export function stylesEqual(left?: EditorTextStyle, right?: EditorTextStyle): boolean {
+export function stylesEqual(
+  left?: EditorTextStyle,
+  right?: EditorTextStyle,
+): boolean {
   return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
 }
 
@@ -49,7 +91,8 @@ export function setBooleanStyle(
   key: ToggleableTextStyleKey,
   enabled: boolean,
 ): EditorTextStyle | undefined {
-  const next = { ...(style ?? {}) } as EditorTextStyle & Record<string, unknown>;
+  const next = { ...(style ?? {}) } as EditorTextStyle &
+    Record<string, unknown>;
 
   if (enabled) {
     next[key] = true;
@@ -83,7 +126,9 @@ export function cloneRun(run: EditorTextRun): EditorTextRun {
   };
 }
 
-export function cloneParagraph(paragraph: EditorParagraphNode): EditorParagraphNode {
+export function cloneParagraph(
+  paragraph: EditorParagraphNode,
+): EditorParagraphNode {
   return {
     ...paragraph,
     runs: paragraph.runs.map(cloneRun),
@@ -111,10 +156,14 @@ export function setParagraphStyleValue<K extends ValueParagraphStyleKey>(
     next[key] = value;
   }
 
-  return Object.keys(next).length > 0 ? (next as EditorParagraphStyle) : undefined;
+  return Object.keys(next).length > 0
+    ? (next as EditorParagraphStyle)
+    : undefined;
 }
 
-export function cloneParagraphs(paragraphs: EditorParagraphNode[]): EditorParagraphNode[] {
+export function cloneParagraphs(
+  paragraphs: EditorParagraphNode[],
+): EditorParagraphNode[] {
   return paragraphs.map(cloneParagraph);
 }
 
@@ -136,7 +185,10 @@ export function cloneBlocks(blocks: EditorBlockNode[]): EditorBlockNode[] {
   });
 }
 
-export function normalizeRuns(runs: EditorTextRun[], fallbackStyles?: EditorTextStyle): EditorTextRun[] {
+export function normalizeRuns(
+  runs: EditorTextRun[],
+  fallbackStyles?: EditorTextStyle,
+): EditorTextRun[] {
   const merged: EditorTextRun[] = [];
 
   for (const run of runs) {
@@ -145,7 +197,12 @@ export function normalizeRuns(runs: EditorTextRun[], fallbackStyles?: EditorText
     }
 
     const previous = merged[merged.length - 1];
-    if (previous && !run.image && !previous.image && stylesEqual(previous.styles, run.styles)) {
+    if (
+      previous &&
+      !run.image &&
+      !previous.image &&
+      stylesEqual(previous.styles, run.styles)
+    ) {
       previous.text += run.text;
       continue;
     }
@@ -207,7 +264,9 @@ export function cloneParagraphWithListLevel(
   return nextParagraph;
 }
 
-export function clearParagraphList(paragraph: EditorParagraphNode): EditorParagraphNode {
+export function clearParagraphList(
+  paragraph: EditorParagraphNode,
+): EditorParagraphNode {
   const nextParagraph = cloneParagraph(paragraph);
   delete nextParagraph.list;
   return nextParagraph;
@@ -222,7 +281,10 @@ export function blocksContainTables(nodes: EditorBlockNode[]): boolean {
   return false;
 }
 
-export function replaceParagraphsInBlocks(blocks: EditorBlockNode[], newParagraphs: EditorParagraphNode[]): EditorBlockNode[] {
+export function replaceParagraphsInBlocks(
+  blocks: EditorBlockNode[],
+  newParagraphs: EditorParagraphNode[],
+): EditorBlockNode[] {
   // Fast path: when the zone contains no tables, the flat paragraph list from
   // `getParagraphs(state)` IS the canonical block list. Replace wholesale so
   // that paragraph-count changes (split, merge via deleteBackward, etc.) are
@@ -234,21 +296,56 @@ export function replaceParagraphsInBlocks(blocks: EditorBlockNode[], newParagrap
 
   let index = 0;
   const processBlocks = (nodes: EditorBlockNode[]): EditorBlockNode[] => {
-    return nodes.map(node => {
+    let changed = false;
+    const newNodes = nodes.map((node) => {
       if (node.type === "paragraph") {
-        return newParagraphs[index++] ?? node;
+        const nextPara = newParagraphs[index++];
+        if (nextPara && nextPara !== node) {
+          changed = true;
+          return nextPara;
+        }
+        return node;
       }
-      return {
-        ...node,
-        rows: node.rows.map(row => ({
-          ...row,
-          cells: row.cells.map(cell => ({
-            ...cell,
-            blocks: processBlocks(cell.blocks) as EditorParagraphNode[]
-          }))
-        }))
-      };
+
+      let nodeChanged = false;
+      const newRows = node.rows.map((row) => {
+        let rowChanged = false;
+        const newCells = row.cells.map((cell) => {
+          const startIdx = index;
+          const newCellBlocks = processBlocks(
+            cell.blocks,
+          ) as EditorParagraphNode[];
+          if (newCellBlocks !== cell.blocks) {
+            rowChanged = true;
+            return {
+              ...cell,
+              blocks: newCellBlocks,
+            };
+          }
+          return cell;
+        });
+
+        if (rowChanged) {
+          nodeChanged = true;
+          return {
+            ...row,
+            cells: newCells,
+          };
+        }
+        return row;
+      });
+
+      if (nodeChanged) {
+        changed = true;
+        return {
+          ...node,
+          rows: newRows,
+        };
+      }
+      return node;
     });
+
+    return changed ? newNodes : nodes;
   };
   return processBlocks(blocks);
 }
@@ -259,14 +356,23 @@ export function replaceParagraphsInSection(
   zone: "main" | "header" | "footer",
 ): EditorSection {
   if (zone === "header") {
-    return { ...section, header: replaceParagraphsInBlocks(section.header ?? [], paragraphs) };
+    return {
+      ...section,
+      header: replaceParagraphsInBlocks(section.header ?? [], paragraphs),
+    };
   }
   if (zone === "footer") {
-    return { ...section, footer: replaceParagraphsInBlocks(section.footer ?? [], paragraphs) };
+    return {
+      ...section,
+      footer: replaceParagraphsInBlocks(section.footer ?? [], paragraphs),
+    };
   }
 
   // main zone: preserve table structure
-  return { ...section, blocks: replaceParagraphsInBlocks(section.blocks, paragraphs) };
+  return {
+    ...section,
+    blocks: replaceParagraphsInBlocks(section.blocks, paragraphs),
+  };
 }
 
 export function cloneStateWithParagraphs(
@@ -274,7 +380,8 @@ export function cloneStateWithParagraphs(
   paragraphs: EditorParagraphNode[],
   selection: EditorSelection,
 ): EditorState {
-  const hasSections = state.document.sections && state.document.sections.length > 0;
+  const hasSections =
+    state.document.sections && state.document.sections.length > 0;
 
   if (hasSections) {
     const sectionIndex = getActiveSectionIndex(state);
@@ -282,7 +389,11 @@ export function cloneStateWithParagraphs(
     const section = state.document.sections![sectionIndex];
 
     if (section) {
-      const updatedSection = replaceParagraphsInSection(section, paragraphs, zone);
+      const updatedSection = replaceParagraphsInSection(
+        section,
+        paragraphs,
+        zone,
+      );
       const updatedSections = [...state.document.sections!];
       updatedSections[sectionIndex] = updatedSection;
 
@@ -298,7 +409,9 @@ export function cloneStateWithParagraphs(
   }
 
   // Legacy fallback: for documents with tables, use replaceParagraphsInBlocks to preserve table structure
-  const hasTableInBlocks = state.document.blocks.some(b => b.type === "table");
+  const hasTableInBlocks = state.document.blocks.some(
+    (b) => b.type === "table",
+  );
 
   if (hasTableInBlocks) {
     return {
@@ -347,7 +460,10 @@ export function getFocusParagraph(state: EditorState): {
   };
 }
 
-export function getStyleAtOffset(paragraph: EditorParagraphNode, offset: number): EditorTextStyle | undefined {
+export function getStyleAtOffset(
+  paragraph: EditorParagraphNode,
+  offset: number,
+): EditorTextStyle | undefined {
   if (paragraph.runs.length === 0) {
     return undefined;
   }
@@ -460,8 +576,14 @@ export function sliceRuns(
   startOffset: number,
   endOffset: number,
 ): EditorTextRun[] {
-  const start = Math.max(0, Math.min(startOffset, getParagraphLength(paragraph)));
-  const end = Math.max(start, Math.min(endOffset, getParagraphLength(paragraph)));
+  const start = Math.max(
+    0,
+    Math.min(startOffset, getParagraphLength(paragraph)),
+  );
+  const end = Math.max(
+    start,
+    Math.min(endOffset, getParagraphLength(paragraph)),
+  );
   const pieces: EditorTextRun[] = [];
 
   let consumed = 0;
@@ -474,7 +596,9 @@ export function sliceRuns(
     if (overlapStart < overlapEnd) {
       const piece: EditorTextRun = {
         id: `run:${Math.random().toString(36).slice(2, 9)}`,
-        text: run.image ? "\uFFFC" : run.text.slice(overlapStart - runStart, overlapEnd - runStart),
+        text: run.image
+          ? "\uFFFC"
+          : run.text.slice(overlapStart - runStart, overlapEnd - runStart),
       };
       if (run.styles) {
         piece.styles = { ...run.styles };
@@ -534,11 +658,17 @@ export function deleteSelectionRange(state: EditorState): EditorState {
     const date = Date.now();
 
     const nextParagraphs = paragraphs.map((paragraph, paragraphIndex) => {
-      if (paragraphIndex < normalized.startIndex || paragraphIndex > normalized.endIndex) {
+      if (
+        paragraphIndex < normalized.startIndex ||
+        paragraphIndex > normalized.endIndex
+      ) {
         return cloneParagraph(paragraph);
       }
 
-      const startOffset = paragraphIndex === normalized.startIndex ? normalized.startParagraphOffset : 0;
+      const startOffset =
+        paragraphIndex === normalized.startIndex
+          ? normalized.startParagraphOffset
+          : 0;
       const endOffset =
         paragraphIndex === normalized.endIndex
           ? normalized.endParagraphOffset
@@ -566,7 +696,10 @@ export function deleteSelectionRange(state: EditorState): EditorState {
 
   const startParagraph = paragraphs[normalized.startIndex];
   const endParagraph = paragraphs[normalized.endIndex];
-  const startOffset = positionToParagraphOffset(startParagraph, normalized.start);
+  const startOffset = positionToParagraphOffset(
+    startParagraph,
+    normalized.start,
+  );
   const endOffset = positionToParagraphOffset(endParagraph, normalized.end);
   const mergedParagraph = buildParagraphFromRuns(startParagraph, [
     ...sliceRuns(startParagraph, 0, startOffset),
@@ -607,12 +740,21 @@ export function preserveSelectionByParagraphOffsets(
   const endParagraph = paragraphs[normalized.endIndex]!;
 
   return {
-    anchor: paragraphOffsetToPosition(startParagraph, normalized.startParagraphOffset),
-    focus: paragraphOffsetToPosition(endParagraph, normalized.endParagraphOffset),
+    anchor: paragraphOffsetToPosition(
+      startParagraph,
+      normalized.startParagraphOffset,
+    ),
+    focus: paragraphOffsetToPosition(
+      endParagraph,
+      normalized.endParagraphOffset,
+    ),
   };
 }
 
-export function collapseToBoundary(state: EditorState, direction: "start" | "end"): EditorState {
+export function collapseToBoundary(
+  state: EditorState,
+  direction: "start" | "end",
+): EditorState {
   const normalized = normalizeSelection(state);
   if (normalized.isCollapsed) {
     return state;
@@ -620,7 +762,9 @@ export function collapseToBoundary(state: EditorState, direction: "start" | "end
 
   return {
     document: state.document,
-    selection: withSelection(direction === "start" ? normalized.start : normalized.end),
+    selection: withSelection(
+      direction === "start" ? normalized.start : normalized.end,
+    ),
   };
 }
 
@@ -719,7 +863,8 @@ export function serializeImageRunToHtml(
   // Asset references must be expanded to the actual data URL so the
   // copied HTML is portable (clipboard consumers don't see our registry).
   const resolvedSrc = resolveImageSrc(document, run.image.src);
-  const altAttr = run.image.alt !== undefined ? ` alt="${escapeHtml(run.image.alt)}"` : "";
+  const altAttr =
+    run.image.alt !== undefined ? ` alt="${escapeHtml(run.image.alt)}"` : "";
   const img = `<img src="${escapeHtml(resolvedSrc)}" width="${Math.max(1, Math.round(run.image.width))}" height="${Math.max(1, Math.round(run.image.height))}"${altAttr}>`;
   if (run.styles?.link) {
     return `<a href="${escapeHtml(run.styles.link)}">${img}</a>`;
@@ -771,10 +916,14 @@ export function serializeParagraphRunsToHtml(
   runs: EditorTextRun[],
   document?: Pick<EditorDocument, "assets">,
 ): string {
-  return runs.map((run) => serializeTextRunToHtml(run, document)).join("") || "<br>";
+  return (
+    runs.map((run) => serializeTextRunToHtml(run, document)).join("") || "<br>"
+  );
 }
 
-export function parseInlineStyles(element: Element): EditorTextStyle | undefined {
+export function parseInlineStyles(
+  element: Element,
+): EditorTextStyle | undefined {
   const style = (element as HTMLElement).style;
   const result: EditorTextStyle = {};
 
@@ -826,7 +975,10 @@ export function parseInlineStyles(element: Element): EditorTextStyle | undefined
     result.subscript = true;
   }
 
-  const link = element.tagName === "A" ? (element as HTMLAnchorElement).getAttribute("href")?.trim() ?? "" : "";
+  const link =
+    element.tagName === "A"
+      ? ((element as HTMLAnchorElement).getAttribute("href")?.trim() ?? "")
+      : "";
   if (link) {
     result.link = link;
     result.underline = true;
@@ -835,7 +987,9 @@ export function parseInlineStyles(element: Element): EditorTextStyle | undefined
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
-export function parseInlineImage(element: Element): EditorImageRunData | undefined {
+export function parseInlineImage(
+  element: Element,
+): EditorImageRunData | undefined {
   if (element.tagName !== "IMG") {
     return undefined;
   }
@@ -850,8 +1004,12 @@ export function parseInlineImage(element: Element): EditorImageRunData | undefin
   const heightAttr = img.getAttribute("height")?.trim() ?? "";
   const widthStyle = img.style.width.trim();
   const heightStyle = img.style.height.trim();
-  const widthFromStyle = widthStyle.endsWith("px") ? Number.parseFloat(widthStyle) : Number.NaN;
-  const heightFromStyle = heightStyle.endsWith("px") ? Number.parseFloat(heightStyle) : Number.NaN;
+  const widthFromStyle = widthStyle.endsWith("px")
+    ? Number.parseFloat(widthStyle)
+    : Number.NaN;
+  const heightFromStyle = heightStyle.endsWith("px")
+    ? Number.parseFloat(heightStyle)
+    : Number.NaN;
   const widthFromAttr = Number.parseFloat(widthAttr);
   const heightFromAttr = Number.parseFloat(heightAttr);
 
@@ -880,12 +1038,19 @@ export function parseInlineImage(element: Element): EditorImageRunData | undefin
   return image;
 }
 
-export function parseParagraphStyle(element: Element): EditorParagraphStyle | undefined {
+export function parseParagraphStyle(
+  element: Element,
+): EditorParagraphStyle | undefined {
   const style = (element as HTMLElement).style;
   const result: EditorParagraphStyle = {};
 
   const align = style.textAlign.trim();
-  if (align === "left" || align === "center" || align === "right" || align === "justify") {
+  if (
+    align === "left" ||
+    align === "center" ||
+    align === "right" ||
+    align === "justify"
+  ) {
     result.align = align;
   }
 
@@ -937,7 +1102,10 @@ export function parseParagraphStyle(element: Element): EditorParagraphStyle | un
     }
   }
 
-  if (style.breakBefore === "page" || (element as HTMLElement).dataset.oasisPageBreakBefore === "true") {
+  if (
+    style.breakBefore === "page" ||
+    (element as HTMLElement).dataset.oasisPageBreakBefore === "true"
+  ) {
     result.pageBreakBefore = true;
   }
 
@@ -951,21 +1119,23 @@ export function parseParagraphStyle(element: Element): EditorParagraphStyle | un
 export function updateTableCellsInBlocks(
   blocks: EditorBlockNode[],
   selectedParagraphIds: Set<string>,
-  updateCell: (cell: EditorTableCellNode) => EditorTableCellNode
+  updateCell: (cell: EditorTableCellNode) => EditorTableCellNode,
 ): EditorBlockNode[] {
-  return blocks.map(block => {
+  return blocks.map((block) => {
     if (block.type === "paragraph") return block;
-    
+
     return {
       ...block,
-      rows: block.rows.map(row => ({
+      rows: block.rows.map((row) => ({
         ...row,
-        cells: row.cells.map(cell => {
+        cells: row.cells.map((cell) => {
           // Check if this cell contains any of the selected paragraphs
-          const isSelected = cell.blocks.some(p => selectedParagraphIds.has(p.id));
+          const isSelected = cell.blocks.some((p) =>
+            selectedParagraphIds.has(p.id),
+          );
           return isSelected ? updateCell(cell) : cell;
-        })
-      }))
+        }),
+      })),
     };
   });
 }
@@ -987,12 +1157,18 @@ export function moveVertical(state: EditorState, delta: -1 | 1): EditorState {
   return {
     document: state.document,
     selection: withSelection(
-      paragraphOffsetToPosition(nextParagraph, Math.min(offset, getParagraphLength(nextParagraph))),
+      paragraphOffsetToPosition(
+        nextParagraph,
+        Math.min(offset, getParagraphLength(nextParagraph)),
+      ),
     ),
   };
 }
 
-export function moveFocusHorizontally(state: EditorState, delta: -1 | 1): EditorState {
+export function moveFocusHorizontally(
+  state: EditorState,
+  delta: -1 | 1,
+): EditorState {
   const focus = clampPosition(state, state.selection.focus);
   const paragraphs = getParagraphs(state);
   const index = findParagraphIndex(paragraphs, focus.paragraphId);
@@ -1018,7 +1194,10 @@ export function moveFocusHorizontally(state: EditorState, delta: -1 | 1): Editor
     const previousParagraph = paragraphs[index - 1];
     return setSelection(state, {
       anchor: state.selection.anchor,
-      focus: paragraphOffsetToPosition(previousParagraph, getParagraphLength(previousParagraph)),
+      focus: paragraphOffsetToPosition(
+        previousParagraph,
+        getParagraphLength(previousParagraph),
+      ),
     });
   }
 
@@ -1033,7 +1212,10 @@ export function moveFocusHorizontally(state: EditorState, delta: -1 | 1): Editor
   return state;
 }
 
-export function moveFocusVertical(state: EditorState, delta: -1 | 1): EditorState {
+export function moveFocusVertical(
+  state: EditorState,
+  delta: -1 | 1,
+): EditorState {
   const focus = clampPosition(state, state.selection.focus);
   const paragraphs = getParagraphs(state);
   const index = findParagraphIndex(paragraphs, focus.paragraphId);
@@ -1048,6 +1230,9 @@ export function moveFocusVertical(state: EditorState, delta: -1 | 1): EditorStat
   const nextParagraph = paragraphs[nextIndex];
   return setSelection(state, {
     anchor: state.selection.anchor,
-    focus: paragraphOffsetToPosition(nextParagraph, Math.min(paragraphOffset, getParagraphLength(nextParagraph))),
+    focus: paragraphOffsetToPosition(
+      nextParagraph,
+      Math.min(paragraphOffset, getParagraphLength(nextParagraph)),
+    ),
   });
 }


### PR DESCRIPTION
Fixes severe performance issues when editing documents with large/complex tables. The text deletion/insertion process was triggering deep clones of the entire document tree. By introducing structural sharing and targeting the localized blocks explicitly, typing latency is drastically reduced.

---
*PR created automatically by Jules for task [12163243420779031377](https://jules.google.com/task/12163243420779031377) started by @celsowm*