### PR TITLE
perf: optimize table operations via structural sharing

### DIFF
--- a/src/app/controllers/useEditorTableOperations.ts
+++ b/src/app/controllers/useEditorTableOperations.ts
@@ -438,7 +438,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, range.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, range.zone);
+    const targetBlocks = [..._tBlocks];
+    if (range.blockIndex >= 0) targetBlocks[range.blockIndex] = cloneBlock(_tBlocks[range.blockIndex]!);
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -483,7 +485,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, range.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, range.zone);
+    const targetBlocks = [..._tBlocks];
+    if (range.blockIndex >= 0) targetBlocks[range.blockIndex] = cloneBlock(_tBlocks[range.blockIndex]!);
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -558,7 +562,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -605,7 +611,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -726,7 +734,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -838,7 +848,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -923,7 +935,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -1026,7 +1040,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
+    const _tBlocks = getTargetBlocks(current, location.zone);
+    const targetBlocks = [..._tBlocks];
+    if (location.blockIndex >= 0) targetBlocks[location.blockIndex] = cloneBlock(_tBlocks[location.blockIndex]!);
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -1189,21 +1205,25 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       targetBlocks = current.document.blocks;
     }
 
-    const nextBlocks = targetBlocks.map(cloneBlock);
-    const tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTable = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTable || originalTable.type !== "table") {
       return edit(current);
     }
 
-    const targetCell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
-    if (!targetCell) {
+    const originalRow = originalTable.rows[location.rowIndex];
+    if (!originalRow) {
+      return edit(current);
+    }
+
+    const originalCell = originalRow.cells[location.cellIndex];
+    if (!originalCell) {
       return edit(current);
     }
 
     const tempState: EditorState = {
       ...current,
       document: createEditorDocument(
-        targetCell.blocks,
+        originalCell.blocks,
         undefined,
         undefined,
         undefined,
@@ -1222,7 +1242,14 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       (block): block is EditorParagraphNode => block.type === "paragraph",
     );
 
-    targetCell.blocks.splice(0, targetCell.blocks.length, ...replacementParagraphs);
+    const nextCell = { ...originalCell, blocks: replacementParagraphs };
+    const nextRow = { ...originalRow, cells: [...originalRow.cells] };
+    nextRow.cells[location.cellIndex] = nextCell;
+    const nextTable = { ...originalTable, rows: [...originalTable.rows] };
+    nextTable.rows[location.rowIndex] = nextRow;
+
+    const nextBlocks = [...targetBlocks];
+    nextBlocks[location.blockIndex] = nextTable;
 
     const nextState = updateBlocksInCurrentSection(current, nextBlocks, zone);
     return {
@@ -1301,7 +1328,9 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       const resultParagraphs = getParagraphs(tempResult);
 
       // 4. Distribute paragraphs back to cells
-      const targetBlocks = getTargetBlocks(current, zone).map(cloneBlock);
+      const _tBlocks = getTargetBlocks(current, zone);
+      const targetBlocks = [..._tBlocks];
+      if (blockIndex >= 0) targetBlocks[blockIndex] = cloneBlock(_tBlocks[blockIndex]!);
       const tableBlock = targetBlocks[blockIndex] as EditorTableNode;
       if (!tableBlock) {
         return current;

--- a/src/core/commands/utils.ts
+++ b/src/core/commands/utils.ts
@@ -234,21 +234,30 @@ export function replaceParagraphsInBlocks(blocks: EditorBlockNode[], newParagrap
 
   let index = 0;
   const processBlocks = (nodes: EditorBlockNode[]): EditorBlockNode[] => {
-    return nodes.map(node => {
+    let changed = false;
+    const nextNodes = nodes.map(node => {
       if (node.type === "paragraph") {
-        return newParagraphs[index++] ?? node;
+        const newP = newParagraphs[index++] ?? node;
+        if (newP !== node) changed = true;
+        return newP;
       }
-      return {
-        ...node,
-        rows: node.rows.map(row => ({
-          ...row,
-          cells: row.cells.map(cell => ({
-            ...cell,
-            blocks: processBlocks(cell.blocks) as EditorParagraphNode[]
-          }))
-        }))
-      };
+
+      let nodeChanged = false;
+      const newRows = node.rows.map(row => {
+        let rowChanged = false;
+        const newCells = row.cells.map(cell => {
+          const newCellBlocks = processBlocks(cell.blocks) as EditorParagraphNode[];
+          if (newCellBlocks !== cell.blocks) rowChanged = true;
+          return newCellBlocks !== cell.blocks ? { ...cell, blocks: newCellBlocks } : cell;
+        });
+        if (rowChanged) nodeChanged = true;
+        return rowChanged ? { ...row, cells: newCells } : row;
+      });
+
+      if (nodeChanged) changed = true;
+      return nodeChanged ? { ...node, rows: newRows } : node;
     });
+    return changed ? nextNodes : nodes;
   };
   return processBlocks(blocks);
 }


### PR DESCRIPTION
Addresses severe performance latency (e.g., thousands of milliseconds for input-to-layout on Backspace/typing) by removing expensive deep clones in `useEditorTableOperations.ts` and `src/core/commands/utils.ts`. Uses structural sharing to keep memory footprint minimal and ensure React/DOM nodes don't aggressively re-render for unaffected document sections.

---
*PR created automatically by Jules for task [13882753791472626938](https://jules.google.com/task/13882753791472626938) started by @celsowm*