### PR TITLE
feat: add isolated PDF export pipeline

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,22 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm install
+
+      - run: npm test
+
+      - run: npm run build:app

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -166,7 +166,7 @@ describe('OasisPdfWriter', () => {
     expect(blob.size).toBeGreaterThan(0);
     expect(pdf.startsWith('%PDF-1.4')).toBe(true);
     expect(pdf).toContain('/MediaBox [0 0 612 792]');
-    expect(pdf).toContain('Oasis PDF section 1');
+    expect(pdf).not.toContain('Oasis PDF section');
     expect(pdf).toContain('Smoke test');
     expect(pdf).toContain('Second ');
     expect(pdf).toContain('paragraph');
@@ -189,7 +189,7 @@ describe('OasisPdfWriter', () => {
     expect(pdf).toContain('463.95 672 Td');
     expect(pdf).toContain('126 650 Td');
     expect(pdf).toContain('90 622 Td');
-    expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(4);
+    expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
   it('creates additional pages when paragraphs overflow the section content area', async () => {
@@ -229,7 +229,7 @@ describe('OasisPdfWriter', () => {
     expect((pdf.match(/\/Type \/Page\n/g) ?? []).length).toBe(2);
     expect(pdf).toContain('Overflow paragraph 1');
     expect(pdf).toContain('Overflow paragraph 12');
-    expect((pdf.match(/Oasis PDF section 1/g) ?? []).length).toBe(2);
+    expect(pdf).not.toContain('Oasis PDF section');
   });
 
   it('renders section headers and footers on every generated page with total page count', async () => {

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import type { EditorDocument } from '../../core/model.js';
+import { layoutPdfParagraph } from '../../export/pdf/layout/layoutParagraph.js';
 import { PdfTextMeasurer } from '../../export/pdf/layout/PdfTextMeasurer.js';
 import { OasisPdfWriter } from '../../export/pdf/OasisPdfWriter.js';
 import { exportEditorDocumentToPdfBlob } from '../../export/pdf/exportEditorDocumentToPdf.js';
 
 function decodePdf(buffer: ArrayBuffer): string {
   return new TextDecoder().decode(buffer);
+}
+
+const PX_TO_PT = 72 / 96;
+
+function pxToPt(value: number): number {
+  return value * PX_TO_PT;
 }
 
 describe('PdfTextMeasurer', () => {
@@ -19,6 +26,30 @@ describe('PdfTextMeasurer', () => {
 
     expect(measurer.measureTextWidth({ text: 'Hello', fontSize: 12 })).toBeCloseTo(27.34, 2);
     expect(measurer.getCacheSize()).toBe(3);
+  });
+});
+
+describe('layoutPdfParagraph', () => {
+  it('wraps paragraph text into measured lines in linear order', () => {
+    const measurer = new PdfTextMeasurer();
+    const layout = layoutPdfParagraph({
+      paragraph: {
+        id: 'wrapped-paragraph',
+        type: 'paragraph',
+        runs: [{ id: 'run-1', text: 'Alpha beta gamma delta' }],
+      },
+      maxWidth: 70,
+      context: { pageNumber: 1, totalPages: 1, measurer },
+      defaultFontSize: 11.25,
+      defaultLineHeight: 16,
+      pxToPt,
+    });
+
+    expect(layout.lines.length).toBeGreaterThan(1);
+    expect(layout.lines.every((line) => line.width <= 70)).toBe(true);
+    expect(layout.lines.map((line) => line.fragments.map((fragment) => fragment.text).join('')).join('')).toBe(
+      'Alpha beta gamma delta',
+    );
   });
 });
 
@@ -201,20 +232,20 @@ describe('OasisPdfWriter', () => {
     expect(pdf).toContain('1 0 0 rg');
     expect(pdf).toContain('1 1 0 rg');
     expect(pdf).toContain('282.864 688 Td');
-    expect(pdf).toContain('474.345 672 Td');
+    expect(pdf).toContain('480.6 672 Td');
     expect(pdf).toContain('126 650 Td');
     expect(pdf).toContain('90 622 Td');
     expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
-  it('creates additional pages when paragraphs overflow the section content area', async () => {
+  it('wraps long paragraphs and creates additional pages when lines overflow the section content area', async () => {
     const document: EditorDocument = {
       id: 'pdf-overflow-document',
       sections: [
         {
           id: 'section-1',
           pageSettings: {
-            width: 816,
+            width: 240,
             height: 240,
             orientation: 'portrait',
             margins: {
@@ -227,11 +258,18 @@ describe('OasisPdfWriter', () => {
               gutter: 0,
             },
           },
-          blocks: Array.from({ length: 12 }, (_, index) => ({
-            id: `overflow-paragraph-${index + 1}`,
-            type: 'paragraph' as const,
-            runs: [{ id: `overflow-run-${index + 1}`, text: `Overflow paragraph ${index + 1}` }],
-          })),
+          blocks: [
+            {
+              id: 'overflow-paragraph',
+              type: 'paragraph',
+              runs: [
+                {
+                  id: 'overflow-run',
+                  text: Array.from({ length: 36 }, (_, index) => `word${index + 1}`).join(' '),
+                },
+              ],
+            },
+          ],
         },
       ],
     };
@@ -242,8 +280,8 @@ describe('OasisPdfWriter', () => {
     expect(blob.type).toBe('application/pdf');
     expect(pdf).toContain('/Count 2');
     expect((pdf.match(/\/Type \/Page\n/g) ?? []).length).toBe(2);
-    expect(pdf).toContain('Overflow paragraph 1');
-    expect(pdf).toContain('Overflow paragraph 12');
+    expect(pdf).toContain('word1 ');
+    expect(pdf).toContain('word36');
     expect(pdf).not.toContain('Oasis PDF section');
   });
 

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { EditorDocument } from '../../core/model.js';
+import { PdfFontRegistry } from '../../export/pdf/fonts/PdfFontRegistry.js';
 import { layoutPdfParagraph } from '../../export/pdf/layout/layoutParagraph.js';
 import { PdfTextMeasurer } from '../../export/pdf/layout/PdfTextMeasurer.js';
 import { OasisPdfWriter } from '../../export/pdf/OasisPdfWriter.js';
@@ -14,6 +15,19 @@ const PX_TO_PT = 72 / 96;
 function pxToPt(value: number): number {
   return value * PX_TO_PT;
 }
+
+describe('PdfFontRegistry', () => {
+  it('resolves built-in Helvetica faces and exposes writer resources', () => {
+    const registry = new PdfFontRegistry();
+
+    expect(registry.resolveFontFace({}).writerResourceName).toBe('F1');
+    expect(registry.resolveFontFace({ bold: true }).writerResourceName).toBe('F2');
+    expect(registry.resolveFontFace({ italic: true }).writerResourceName).toBe('F3');
+    expect(registry.resolveFontFace({ bold: true, italic: true }).writerResourceName).toBe('F4');
+    expect(registry.resolveFontFace({ fontFamily: 'Unknown Font', bold: true }).writerResourceName).toBe('F2');
+    expect(registry.getPdfFontResources().map((resource) => resource.resourceName)).toEqual(['F1', 'F2', 'F3', 'F4']);
+  });
+});
 
 describe('PdfTextMeasurer', () => {
   it('measures text using cached PDF font metrics', () => {
@@ -116,6 +130,29 @@ describe('OasisPdfWriter', () => {
     expect(pdf).toContain('trailer');
     expect(pdf).toContain('startxref');
     expect(pdf.trim().endsWith('%%EOF')).toBe(true);
+  });
+
+  it('uses explicitly registered font resource names', () => {
+    const writer = new OasisPdfWriter([
+      { kind: 'base14', resourceName: 'CustomRegular', baseFont: 'Helvetica' },
+      { kind: 'base14', resourceName: 'CustomBold', baseFont: 'Helvetica-Bold' },
+    ]);
+    const pageIndex = writer.addPage({ width: 300, height: 300 });
+
+    writer.drawText(pageIndex, {
+      x: 24,
+      y: 48,
+      text: 'Custom font resource',
+      fontSize: 12,
+      fontResourceName: 'CustomBold',
+    });
+
+    const pdf = decodePdf(writer.toArrayBuffer());
+
+    expect(pdf).toContain('/CustomRegular');
+    expect(pdf).toContain('/CustomBold');
+    expect(pdf).toContain('/CustomBold 12 Tf');
+    expect(pdf).toContain('/Helvetica-Bold');
   });
 
   it('exports an editor document to an application/pdf blob with paragraph text and basic inline styles', async () => {

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorDocument } from '../../core/model.js';
+import { OasisPdfWriter } from '../../export/pdf/OasisPdfWriter.js';
+import { exportEditorDocumentToPdfBlob } from '../../export/pdf/exportEditorDocumentToPdf.js';
+
+function decodePdf(buffer: ArrayBuffer): string {
+  return new TextDecoder().decode(buffer);
+}
+
+describe('OasisPdfWriter', () => {
+  it('writes a structurally valid PDF with basic drawing commands', () => {
+    const writer = new OasisPdfWriter();
+    const pageIndex = writer.addPage({ width: 612, height: 792 });
+
+    writer.drawRect(pageIndex, {
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      fill: '#ffffff',
+      stroke: '#111827',
+      lineWidth: 1,
+    });
+    writer.drawLine(pageIndex, {
+      x1: 10,
+      y1: 90,
+      x2: 110,
+      y2: 90,
+      stroke: '#d1d5db',
+      lineWidth: 0.75,
+    });
+    writer.drawText(pageIndex, {
+      x: 24,
+      y: 48,
+      text: 'Hello PDF',
+      fontSize: 12,
+      color: '#111827',
+    });
+    writer.drawText(pageIndex, {
+      x: 24,
+      y: 68,
+      text: 'Bold italic PDF',
+      fontSize: 14,
+      color: '#ff0000',
+      bold: true,
+      italic: true,
+    });
+
+    const blob = writer.toBlob();
+    const pdf = decodePdf(writer.toArrayBuffer());
+
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(0);
+    expect(pdf.startsWith('%PDF-1.4')).toBe(true);
+    expect(pdf).toContain('/Catalog');
+    expect(pdf).toContain('/Pages');
+    expect(pdf).toContain('/Page');
+    expect(pdf).toContain('/MediaBox [0 0 612 792]');
+    expect(pdf).toContain('/Contents');
+    expect(pdf).toContain('/Font');
+    expect(pdf).toContain('/Helvetica');
+    expect(pdf).toContain('/Helvetica-Bold');
+    expect(pdf).toContain('/Helvetica-Oblique');
+    expect(pdf).toContain('/Helvetica-BoldOblique');
+    expect(pdf).toContain('Hello PDF');
+    expect(pdf).toContain('Bold italic PDF');
+    expect(pdf).toContain('/F4 14 Tf');
+    expect(pdf).toContain('1 0 0 rg');
+    expect(pdf).toContain('xref');
+    expect(pdf).toContain('trailer');
+    expect(pdf).toContain('startxref');
+    expect(pdf.trim().endsWith('%%EOF')).toBe(true);
+  });
+
+  it('exports an editor document to an application/pdf blob with paragraph text and basic inline styles', async () => {
+    const document: EditorDocument = {
+      id: 'pdf-smoke-document',
+      sections: [
+        {
+          id: 'section-1',
+          pageSettings: {
+            width: 816,
+            height: 1056,
+            orientation: 'portrait',
+            margins: {
+              top: 96,
+              right: 96,
+              bottom: 96,
+              left: 96,
+              header: 48,
+              footer: 48,
+              gutter: 0,
+            },
+          },
+          blocks: [
+            {
+              id: 'paragraph-1',
+              type: 'paragraph',
+              runs: [{ id: 'run-1', text: 'Smoke test' }],
+            },
+            {
+              id: 'paragraph-2',
+              type: 'paragraph',
+              runs: [
+                { id: 'run-2', text: 'Second ', styles: { bold: true, underline: true, highlight: '#ffff00' } },
+                { id: 'run-3', text: 'paragraph', styles: { italic: true, strike: true, color: '#ff0000', fontSize: 20 } },
+              ],
+            },
+            {
+              id: 'paragraph-3',
+              type: 'paragraph',
+              style: { align: 'center' },
+              runs: [{ id: 'run-4', text: 'Centered' }],
+            },
+            {
+              id: 'paragraph-4',
+              type: 'paragraph',
+              style: { align: 'right' },
+              runs: [{ id: 'run-5', text: 'Right aligned' }],
+            },
+            {
+              id: 'paragraph-5',
+              type: 'paragraph',
+              style: {
+                spacingBefore: 8,
+                spacingAfter: 16,
+                indentLeft: 48,
+                indentRight: 24,
+                indentFirstLine: 24,
+              },
+              runs: [{ id: 'run-6', text: 'Indented paragraph' }],
+            },
+            {
+              id: 'paragraph-6',
+              type: 'paragraph',
+              style: { indentLeft: 48, indentHanging: 24 },
+              runs: [{ id: 'run-7', text: 'Hanging paragraph' }],
+            },
+            {
+              id: 'paragraph-7',
+              type: 'paragraph',
+              list: { kind: 'bullet' },
+              runs: [{ id: 'run-8', text: 'Bullet item' }],
+            },
+            {
+              id: 'paragraph-8',
+              type: 'paragraph',
+              list: { kind: 'ordered', startAt: 3 },
+              runs: [{ id: 'run-9', text: 'Ordered item' }],
+            },
+            {
+              id: 'paragraph-9',
+              type: 'paragraph',
+              list: { kind: 'ordered', format: 'upperLetter' },
+              runs: [{ id: 'run-10', text: 'Letter item' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blob = await exportEditorDocumentToPdfBlob(document);
+    const pdf = await blob.text();
+
+    expect(blob.type).toBe('application/pdf');
+    expect(blob.size).toBeGreaterThan(0);
+    expect(pdf.startsWith('%PDF-1.4')).toBe(true);
+    expect(pdf).toContain('/MediaBox [0 0 612 792]');
+    expect(pdf).toContain('Oasis PDF section 1');
+    expect(pdf).toContain('Smoke test');
+    expect(pdf).toContain('Second ');
+    expect(pdf).toContain('paragraph');
+    expect(pdf).toContain('Centered');
+    expect(pdf).toContain('Right aligned');
+    expect(pdf).toContain('Indented paragraph');
+    expect(pdf).toContain('Hanging paragraph');
+    expect(pdf).toContain('Bullet item');
+    expect(pdf).toContain('Ordered item');
+    expect(pdf).toContain('Letter item');
+    expect(pdf).toContain('(•) Tj');
+    expect(pdf).toContain('(3.) Tj');
+    expect(pdf).toContain('(A.) Tj');
+    expect(pdf).not.toContain('(4.) Tj');
+    expect(pdf).toContain('/F2 11.25 Tf');
+    expect(pdf).toContain('/F3 15 Tf');
+    expect(pdf).toContain('1 0 0 rg');
+    expect(pdf).toContain('1 1 0 rg');
+    expect(pdf).toContain('282.6 688 Td');
+    expect(pdf).toContain('463.95 672 Td');
+    expect(pdf).toContain('126 650 Td');
+    expect(pdf).toContain('90 622 Td');
+    expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('creates additional pages when paragraphs overflow the section content area', async () => {
+    const document: EditorDocument = {
+      id: 'pdf-overflow-document',
+      sections: [
+        {
+          id: 'section-1',
+          pageSettings: {
+            width: 816,
+            height: 240,
+            orientation: 'portrait',
+            margins: {
+              top: 48,
+              right: 48,
+              bottom: 48,
+              left: 48,
+              header: 24,
+              footer: 24,
+              gutter: 0,
+            },
+          },
+          blocks: Array.from({ length: 12 }, (_, index) => ({
+            id: `overflow-paragraph-${index + 1}`,
+            type: 'paragraph' as const,
+            runs: [{ id: `overflow-run-${index + 1}`, text: `Overflow paragraph ${index + 1}` }],
+          })),
+        },
+      ],
+    };
+
+    const blob = await exportEditorDocumentToPdfBlob(document);
+    const pdf = await blob.text();
+
+    expect(blob.type).toBe('application/pdf');
+    expect(pdf).toContain('/Count 2');
+    expect((pdf.match(/\/Type \/Page\n/g) ?? []).length).toBe(2);
+    expect(pdf).toContain('Overflow paragraph 1');
+    expect(pdf).toContain('Overflow paragraph 12');
+    expect((pdf.match(/Oasis PDF section 1/g) ?? []).length).toBe(2);
+  });
+
+  it('renders section headers and footers on every generated page with total page count', async () => {
+    const document: EditorDocument = {
+      id: 'pdf-header-footer-document',
+      sections: [
+        {
+          id: 'section-1',
+          pageSettings: {
+            width: 816,
+            height: 240,
+            orientation: 'portrait',
+            margins: {
+              top: 48,
+              right: 48,
+              bottom: 48,
+              left: 48,
+              header: 24,
+              footer: 24,
+              gutter: 0,
+            },
+          },
+          header: [
+            {
+              id: 'header-paragraph',
+              type: 'paragraph',
+              runs: [{ id: 'header-run', text: 'Document header' }],
+            },
+          ],
+          footer: [
+            {
+              id: 'footer-paragraph',
+              type: 'paragraph',
+              runs: [
+                { id: 'footer-label', text: 'Page ' },
+                { id: 'footer-page', text: '', field: { type: 'PAGE' } },
+                { id: 'footer-of', text: ' of ' },
+                { id: 'footer-total', text: '', field: { type: 'NUMPAGES' } },
+              ],
+            },
+          ],
+          blocks: Array.from({ length: 12 }, (_, index) => ({
+            id: `body-paragraph-${index + 1}`,
+            type: 'paragraph' as const,
+            runs: [{ id: `body-run-${index + 1}`, text: `Body paragraph ${index + 1}` }],
+          })),
+        },
+      ],
+    };
+
+    const blob = await exportEditorDocumentToPdfBlob(document);
+    const pdf = await blob.text();
+
+    expect(blob.type).toBe('application/pdf');
+    expect(pdf).toContain('/Count 2');
+    expect((pdf.match(/Document header/g) ?? []).length).toBe(2);
+    expect((pdf.match(/Page /g) ?? []).length).toBe(2);
+    expect((pdf.match(/ of /g) ?? []).length).toBe(2);
+    expect(pdf).toContain('(1) Tj');
+    expect((pdf.match(/\(2\) Tj/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from 'vitest';
 import type { EditorDocument } from '../../core/model.js';
+import { PdfTextMeasurer } from '../../export/pdf/layout/PdfTextMeasurer.js';
 import { OasisPdfWriter } from '../../export/pdf/OasisPdfWriter.js';
 import { exportEditorDocumentToPdfBlob } from '../../export/pdf/exportEditorDocumentToPdf.js';
 
 function decodePdf(buffer: ArrayBuffer): string {
   return new TextDecoder().decode(buffer);
 }
+
+describe('PdfTextMeasurer', () => {
+  it('measures text using cached PDF font metrics', () => {
+    const measurer = new PdfTextMeasurer();
+
+    expect(measurer.measureTextWidth({ text: 'iii', fontSize: 10 })).toBeCloseTo(6.66, 2);
+    expect(measurer.measureTextWidth({ text: 'WWW', fontSize: 10 })).toBeCloseTo(28.32, 2);
+    expect(measurer.measureTextWidth({ text: 'Hello', fontSize: 12 })).toBeCloseTo(27.34, 2);
+    expect(measurer.getCacheSize()).toBe(3);
+
+    expect(measurer.measureTextWidth({ text: 'Hello', fontSize: 12 })).toBeCloseTo(27.34, 2);
+    expect(measurer.getCacheSize()).toBe(3);
+  });
+});
 
 describe('OasisPdfWriter', () => {
   it('writes a structurally valid PDF with basic drawing commands', () => {
@@ -185,8 +200,8 @@ describe('OasisPdfWriter', () => {
     expect(pdf).toContain('/F3 15 Tf');
     expect(pdf).toContain('1 0 0 rg');
     expect(pdf).toContain('1 1 0 rg');
-    expect(pdf).toContain('282.6 688 Td');
-    expect(pdf).toContain('463.95 672 Td');
+    expect(pdf).toContain('282.864 688 Td');
+    expect(pdf).toContain('474.345 672 Td');
     expect(pdf).toContain('126 650 Td');
     expect(pdf).toContain('90 622 Td');
     expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(2);

--- a/src/__tests__/export/pdfWriter.test.ts
+++ b/src/__tests__/export/pdfWriter.test.ts
@@ -213,16 +213,18 @@ describe('OasisPdfWriter', () => {
     expect(pdf.startsWith('%PDF-1.4')).toBe(true);
     expect(pdf).toContain('/MediaBox [0 0 612 792]');
     expect(pdf).not.toContain('Oasis PDF section');
-    expect(pdf).toContain('Smoke test');
-    expect(pdf).toContain('Second ');
-    expect(pdf).toContain('paragraph');
-    expect(pdf).toContain('Centered');
-    expect(pdf).toContain('Right aligned');
-    expect(pdf).toContain('Indented paragraph');
-    expect(pdf).toContain('Hanging paragraph');
-    expect(pdf).toContain('Bullet item');
-    expect(pdf).toContain('Ordered item');
-    expect(pdf).toContain('Letter item');
+    expect(pdf).toContain('(Smoke ) Tj');
+    expect(pdf).toContain('(test) Tj');
+    expect(pdf).toContain('(Second ) Tj');
+    expect(pdf).toContain('(paragraph) Tj');
+    expect(pdf).toContain('(Centered) Tj');
+    expect(pdf).toContain('(Right ) Tj');
+    expect(pdf).toContain('(aligned) Tj');
+    expect(pdf).toContain('(Indented ) Tj');
+    expect(pdf).toContain('(Hanging ) Tj');
+    expect(pdf).toContain('(Bullet ) Tj');
+    expect(pdf).toContain('(Ordered ) Tj');
+    expect(pdf).toContain('(Letter ) Tj');
     expect(pdf).toContain('(•) Tj');
     expect(pdf).toContain('(3.) Tj');
     expect(pdf).toContain('(A.) Tj');
@@ -231,10 +233,10 @@ describe('OasisPdfWriter', () => {
     expect(pdf).toContain('/F3 15 Tf');
     expect(pdf).toContain('1 0 0 rg');
     expect(pdf).toContain('1 1 0 rg');
-    expect(pdf).toContain('282.864 688 Td');
-    expect(pdf).toContain('480.6 672 Td');
-    expect(pdf).toContain('126 650 Td');
-    expect(pdf).toContain('90 622 Td');
+    expect(pdf).toContain('282.864 686 Td');
+    expect(pdf).toContain('474.345 670 Td');
+    expect(pdf).toContain('126 648 Td');
+    expect(pdf).toContain('90 620 Td');
     expect((pdf.match(/\nS\nQ/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
@@ -276,12 +278,13 @@ describe('OasisPdfWriter', () => {
 
     const blob = await exportEditorDocumentToPdfBlob(document);
     const pdf = await blob.text();
+    const pageCount = (pdf.match(/\/Type \/Page\n/g) ?? []).length;
 
     expect(blob.type).toBe('application/pdf');
-    expect(pdf).toContain('/Count 2');
-    expect((pdf.match(/\/Type \/Page\n/g) ?? []).length).toBe(2);
-    expect(pdf).toContain('word1 ');
-    expect(pdf).toContain('word36');
+    expect(pageCount).toBeGreaterThan(1);
+    expect(pdf).toContain(`/Count ${pageCount}`);
+    expect(pdf).toContain('(word1 ) Tj');
+    expect(pdf).toContain('(word36) Tj');
     expect(pdf).not.toContain('Oasis PDF section');
   });
 
@@ -292,7 +295,7 @@ describe('OasisPdfWriter', () => {
         {
           id: 'section-1',
           pageSettings: {
-            width: 816,
+            width: 240,
             height: 240,
             orientation: 'portrait',
             margins: {
@@ -324,7 +327,7 @@ describe('OasisPdfWriter', () => {
               ],
             },
           ],
-          blocks: Array.from({ length: 12 }, (_, index) => ({
+          blocks: Array.from({ length: 36 }, (_, index) => ({
             id: `body-paragraph-${index + 1}`,
             type: 'paragraph' as const,
             runs: [{ id: `body-run-${index + 1}`, text: `Body paragraph ${index + 1}` }],
@@ -335,13 +338,16 @@ describe('OasisPdfWriter', () => {
 
     const blob = await exportEditorDocumentToPdfBlob(document);
     const pdf = await blob.text();
+    const pageCount = (pdf.match(/\/Type \/Page\n/g) ?? []).length;
 
     expect(blob.type).toBe('application/pdf');
-    expect(pdf).toContain('/Count 2');
-    expect((pdf.match(/Document header/g) ?? []).length).toBe(2);
-    expect((pdf.match(/Page /g) ?? []).length).toBe(2);
-    expect((pdf.match(/ of /g) ?? []).length).toBe(2);
+    expect(pageCount).toBeGreaterThan(1);
+    expect(pdf).toContain(`/Count ${pageCount}`);
+    expect((pdf.match(/Document /g) ?? []).length).toBe(pageCount);
+    expect((pdf.match(/header/g) ?? []).length).toBe(pageCount);
+    expect((pdf.match(/Page /g) ?? []).length).toBe(pageCount);
+    expect((pdf.match(/of /g) ?? []).length).toBe(pageCount);
     expect(pdf).toContain('(1) Tj');
-    expect((pdf.match(/\(2\) Tj/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(pdf).toContain(`(${pageCount}) Tj`);
   });
 });

--- a/src/app/controllers/useEditorDocumentIO.ts
+++ b/src/app/controllers/useEditorDocumentIO.ts
@@ -16,6 +16,7 @@ import {
   setSelection,
 } from "../../core/editorCommands.js";
 import { exportEditorDocumentToDocxBlob } from "../../export/docx/exportEditorDocumentToDocx.js";
+import { exportEditorDocumentToPdfBlob } from "../../export/pdf/exportEditorDocumentToPdf.js";
 import { importDocxInWorker } from "../../import/docx/importDocxInWorker.js";
 import type { DocxImportStage } from "../../import/docx/importDocxToEditorDocument.js";
 import { getMaxInlineImageWidth } from "../../ui/imageGeometry.js";
@@ -83,6 +84,15 @@ export function createEditorDocumentIO(deps: UseEditorDocumentIOProps) {
         current?.phase === "done" || current?.phase === "error" ? null : current,
       );
     }, 1200);
+  };
+
+  const downloadBlob = (blob: Blob, filename: string) => {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(url);
   };
 
   const handleImportDocx = async (file: File | null) => {
@@ -231,12 +241,13 @@ export function createEditorDocumentIO(deps: UseEditorDocumentIOProps) {
 
   const handleExportDocx = async () => {
     const blob = await exportEditorDocumentToDocxBlob(deps.state().document);
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = "oasis-editor.docx";
-    anchor.click();
-    URL.revokeObjectURL(url);
+    downloadBlob(blob, "oasis-editor.docx");
+    deps.focusInput();
+  };
+
+  const handleExportPdf = async () => {
+    const blob = await exportEditorDocumentToPdfBlob(deps.state().document);
+    downloadBlob(blob, "oasis-editor.pdf");
     deps.focusInput();
   };
 
@@ -244,6 +255,7 @@ export function createEditorDocumentIO(deps: UseEditorDocumentIOProps) {
     importProgress,
     handleImportDocx,
     handleExportDocx,
+    handleExportPdf,
     insertImageFromFile,
     handleInsertImage,
   };

--- a/src/app/controllers/useEditorToolbar.ts
+++ b/src/app/controllers/useEditorToolbar.ts
@@ -97,6 +97,7 @@ export function createEditorToolbarController(deps: UseEditorToolbarProps) {
     tableActionRestrictionLabel: deps.tableOps.tableActionRestrictionLabel,
     isInsideTable,
     handleExportDocx: deps.docIO.handleExportDocx,
+    handleExportPdf: deps.docIO.handleExportPdf,
     toggleFindReplace: deps.toggleFindReplace,
     performUndo: deps.historyActions.performUndo,
     performRedo: deps.historyActions.performRedo,

--- a/src/export/pdf/OasisPdfWriter.ts
+++ b/src/export/pdf/OasisPdfWriter.ts
@@ -36,6 +36,15 @@ export interface OasisPdfTextOptions {
   color?: string;
   bold?: boolean;
   italic?: boolean;
+  fontResourceName?: string;
+}
+
+export type OasisPdfFontResource = OasisPdfBase14FontResource;
+
+export interface OasisPdfBase14FontResource {
+  kind: "base14";
+  resourceName: string;
+  baseFont: string;
 }
 
 interface PdfObject {
@@ -43,17 +52,12 @@ interface PdfObject {
   body: string;
 }
 
-interface PdfFontResource {
-  name: string;
-  baseFont: string;
-}
-
 const PDF_HEADER = "%PDF-1.4\n% Oasis PDF\n";
-const PDF_FONT_RESOURCES: PdfFontResource[] = [
-  { name: "F1", baseFont: "Helvetica" },
-  { name: "F2", baseFont: "Helvetica-Bold" },
-  { name: "F3", baseFont: "Helvetica-Oblique" },
-  { name: "F4", baseFont: "Helvetica-BoldOblique" },
+const DEFAULT_PDF_FONT_RESOURCES: OasisPdfFontResource[] = [
+  { kind: "base14", resourceName: "F1", baseFont: "Helvetica" },
+  { kind: "base14", resourceName: "F2", baseFont: "Helvetica-Bold" },
+  { kind: "base14", resourceName: "F3", baseFont: "Helvetica-Oblique" },
+  { kind: "base14", resourceName: "F4", baseFont: "Helvetica-BoldOblique" },
 ];
 
 function formatNumber(value: number): string {
@@ -102,7 +106,10 @@ function colorCommand(
   return `${formatNumber(r)} ${formatNumber(g)} ${formatNumber(b)} ${operator}`;
 }
 
-function resolveFontName(options: Pick<OasisPdfTextOptions, "bold" | "italic">): string {
+function resolveFontName(options: Pick<OasisPdfTextOptions, "bold" | "italic" | "fontResourceName">): string {
+  if (options.fontResourceName) {
+    return options.fontResourceName;
+  }
   if (options.bold && options.italic) {
     return "F4";
   }
@@ -115,8 +122,26 @@ function resolveFontName(options: Pick<OasisPdfTextOptions, "bold" | "italic">):
   return "F1";
 }
 
+function fontResourceObjectBody(resource: OasisPdfFontResource): string {
+  switch (resource.kind) {
+    case "base14":
+      return `<< /Type /Font /Subtype /Type1 /BaseFont /${resource.baseFont} >>`;
+  }
+}
+
 export class OasisPdfWriter {
   private readonly pages: OasisPdfPage[] = [];
+  private readonly fontResources = new Map<string, OasisPdfFontResource>();
+
+  constructor(fontResources: OasisPdfFontResource[] = DEFAULT_PDF_FONT_RESOURCES) {
+    for (const resource of fontResources) {
+      this.registerFontResource(resource);
+    }
+  }
+
+  registerFontResource(resource: OasisPdfFontResource): void {
+    this.fontResources.set(resource.resourceName, resource);
+  }
 
   addPage(size: OasisPdfPageSize): number {
     this.pages.push({
@@ -221,11 +246,10 @@ export class OasisPdfWriter {
 
     const catalogObjectId = addObject("");
     const pagesObjectId = addObject("");
-    const fontObjectIds = PDF_FONT_RESOURCES.map((font) =>
-      addObject(`<< /Type /Font /Subtype /Type1 /BaseFont /${font.baseFont} >>`),
-    );
-    const fontResourceXml = PDF_FONT_RESOURCES
-      .map((font, index) => `/${font.name} ${fontObjectIds[index]} 0 R`)
+    const fontResourceEntries = Array.from(this.fontResources.values());
+    const fontObjectIds = fontResourceEntries.map((font) => addObject(fontResourceObjectBody(font)));
+    const fontResourceXml = fontResourceEntries
+      .map((font, index) => `/${font.resourceName} ${fontObjectIds[index]} 0 R`)
       .join(" ");
     const pageObjectIds: number[] = [];
 

--- a/src/export/pdf/OasisPdfWriter.ts
+++ b/src/export/pdf/OasisPdfWriter.ts
@@ -1,0 +1,278 @@
+export interface OasisPdfPageSize {
+  width: number;
+  height: number;
+}
+
+export interface OasisPdfPage {
+  width: number;
+  height: number;
+  commands: string[];
+}
+
+export interface OasisPdfRectOptions {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  fill?: string;
+  stroke?: string;
+  lineWidth?: number;
+}
+
+export interface OasisPdfLineOptions {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  stroke?: string;
+  lineWidth?: number;
+}
+
+export interface OasisPdfTextOptions {
+  x: number;
+  y: number;
+  text: string;
+  fontSize?: number;
+  color?: string;
+  bold?: boolean;
+  italic?: boolean;
+}
+
+interface PdfObject {
+  id: number;
+  body: string;
+}
+
+interface PdfFontResource {
+  name: string;
+  baseFont: string;
+}
+
+const PDF_HEADER = "%PDF-1.4\n% Oasis PDF\n";
+const PDF_FONT_RESOURCES: PdfFontResource[] = [
+  { name: "F1", baseFont: "Helvetica" },
+  { name: "F2", baseFont: "Helvetica-Bold" },
+  { name: "F3", baseFont: "Helvetica-Oblique" },
+  { name: "F4", baseFont: "Helvetica-BoldOblique" },
+];
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  return Number(value.toFixed(3)).toString();
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function escapePdfString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\(/g, "\\(")
+    .replace(/\)/g, "\\)")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n");
+}
+
+function colorToRgb(color: string | undefined, fallback: [number, number, number]): [number, number, number] {
+  if (!color) {
+    return fallback;
+  }
+
+  const normalized = color.trim().replace(/^#/, "");
+  if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+    return fallback;
+  }
+
+  return [
+    Number.parseInt(normalized.slice(0, 2), 16) / 255,
+    Number.parseInt(normalized.slice(2, 4), 16) / 255,
+    Number.parseInt(normalized.slice(4, 6), 16) / 255,
+  ];
+}
+
+function colorCommand(
+  color: string | undefined,
+  operator: "rg" | "RG",
+  fallback: [number, number, number],
+): string {
+  const [r, g, b] = colorToRgb(color, fallback);
+  return `${formatNumber(r)} ${formatNumber(g)} ${formatNumber(b)} ${operator}`;
+}
+
+function resolveFontName(options: Pick<OasisPdfTextOptions, "bold" | "italic">): string {
+  if (options.bold && options.italic) {
+    return "F4";
+  }
+  if (options.bold) {
+    return "F2";
+  }
+  if (options.italic) {
+    return "F3";
+  }
+  return "F1";
+}
+
+export class OasisPdfWriter {
+  private readonly pages: OasisPdfPage[] = [];
+
+  addPage(size: OasisPdfPageSize): number {
+    this.pages.push({
+      width: Math.max(1, size.width),
+      height: Math.max(1, size.height),
+      commands: [],
+    });
+    return this.pages.length - 1;
+  }
+
+  getPageCount(): number {
+    return this.pages.length;
+  }
+
+  drawRect(pageIndex: number, options: OasisPdfRectOptions): void {
+    const page = this.pages[pageIndex];
+    if (!page || options.width <= 0 || options.height <= 0) {
+      return;
+    }
+
+    const commands = ["q"];
+    if (options.fill) {
+      commands.push(colorCommand(options.fill, "rg", [1, 1, 1]));
+    }
+    if (options.stroke) {
+      commands.push(colorCommand(options.stroke, "RG", [0, 0, 0]));
+      commands.push(`${formatNumber(options.lineWidth ?? 1)} w`);
+    }
+
+    commands.push([
+      formatNumber(options.x),
+      formatNumber(page.height - options.y - options.height),
+      formatNumber(options.width),
+      formatNumber(options.height),
+      "re",
+    ].join(" "));
+
+    if (options.fill && options.stroke) {
+      commands.push("B");
+    } else if (options.fill) {
+      commands.push("f");
+    } else if (options.stroke) {
+      commands.push("S");
+    }
+    commands.push("Q");
+    page.commands.push(commands.join("\n"));
+  }
+
+  drawLine(pageIndex: number, options: OasisPdfLineOptions): void {
+    const page = this.pages[pageIndex];
+    if (!page) {
+      return;
+    }
+
+    page.commands.push([
+      "q",
+      colorCommand(options.stroke, "RG", [0, 0, 0]),
+      `${formatNumber(options.lineWidth ?? 1)} w`,
+      `${formatNumber(options.x1)} ${formatNumber(page.height - options.y1)} m`,
+      `${formatNumber(options.x2)} ${formatNumber(page.height - options.y2)} l`,
+      "S",
+      "Q",
+    ].join("\n"));
+  }
+
+  drawText(pageIndex: number, options: OasisPdfTextOptions): void {
+    const page = this.pages[pageIndex];
+    if (!page || options.text.length === 0) {
+      return;
+    }
+
+    page.commands.push([
+      "BT",
+      colorCommand(options.color, "rg", [0, 0, 0]),
+      `/${resolveFontName(options)} ${formatNumber(options.fontSize ?? 12)} Tf`,
+      `${formatNumber(options.x)} ${formatNumber(page.height - options.y)} Td`,
+      `(${escapePdfString(options.text)}) Tj`,
+      "ET",
+    ].join("\n"));
+  }
+
+  toArrayBuffer(): ArrayBuffer {
+    const bytes = this.toUint8Array();
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  }
+
+  toBlob(): Blob {
+    return new Blob([this.toArrayBuffer()], { type: "application/pdf" });
+  }
+
+  private toUint8Array(): Uint8Array {
+    if (this.pages.length === 0) {
+      this.addPage({ width: 612, height: 792 });
+    }
+
+    const objects: PdfObject[] = [];
+    const addObject = (body: string): number => {
+      const id = objects.length + 1;
+      objects.push({ id, body });
+      return id;
+    };
+
+    const catalogObjectId = addObject("");
+    const pagesObjectId = addObject("");
+    const fontObjectIds = PDF_FONT_RESOURCES.map((font) =>
+      addObject(`<< /Type /Font /Subtype /Type1 /BaseFont /${font.baseFont} >>`),
+    );
+    const fontResourceXml = PDF_FONT_RESOURCES
+      .map((font, index) => `/${font.name} ${fontObjectIds[index]} 0 R`)
+      .join(" ");
+    const pageObjectIds: number[] = [];
+
+    for (const page of this.pages) {
+      const stream = `${page.commands.join("\n")}\n`;
+      const contentObjectId = addObject(`<< /Length ${byteLength(stream)} >>\nstream\n${stream}endstream`);
+      const pageObjectId = addObject([
+        "<< /Type /Page",
+        `/Parent ${pagesObjectId} 0 R`,
+        `/MediaBox [0 0 ${formatNumber(page.width)} ${formatNumber(page.height)}]`,
+        `/Resources << /Font << ${fontResourceXml} >> >>`,
+        `/Contents ${contentObjectId} 0 R`,
+        ">>",
+      ].join("\n"));
+      pageObjectIds.push(pageObjectId);
+    }
+
+    objects[catalogObjectId - 1]!.body = `<< /Type /Catalog /Pages ${pagesObjectId} 0 R >>`;
+    objects[pagesObjectId - 1]!.body = [
+      "<< /Type /Pages",
+      `/Kids [${pageObjectIds.map((id) => `${id} 0 R`).join(" ")}]`,
+      `/Count ${pageObjectIds.length}`,
+      ">>",
+    ].join("\n");
+
+    let body = PDF_HEADER;
+    const offsets: number[] = [0];
+    for (const object of objects) {
+      offsets[object.id] = byteLength(body);
+      body += `${object.id} 0 obj\n${object.body}\nendobj\n`;
+    }
+
+    const xrefOffset = byteLength(body);
+    body += `xref\n0 ${objects.length + 1}\n`;
+    body += "0000000000 65535 f \n";
+    for (const object of objects) {
+      body += `${String(offsets[object.id] ?? 0).padStart(10, "0")} 00000 n \n`;
+    }
+    body += [
+      "trailer",
+      `<< /Size ${objects.length + 1} /Root ${catalogObjectId} 0 R >>`,
+      "startxref",
+      String(xrefOffset),
+      "%%EOF",
+      "",
+    ].join("\n");
+
+    return new TextEncoder().encode(body);
+  }
+}

--- a/src/export/pdf/exportEditorDocumentToPdf.ts
+++ b/src/export/pdf/exportEditorDocumentToPdf.ts
@@ -7,11 +7,9 @@ import type {
   EditorTextRun,
 } from "../../core/model.js";
 import { getDocumentSections } from "../../core/model.js";
+import { PdfFontRegistry } from "./fonts/PdfFontRegistry.js";
 import {
   layoutPdfParagraph,
-  measurePdfRunTextWidthPt,
-  pdfRunFontSizePt,
-  resolvePdfRunText,
   type PdfParagraphFragment,
   type PdfParagraphLine,
   type PdfParagraphTextContext,
@@ -36,6 +34,10 @@ interface PdfHeaderFooterPage {
   margins: EditorPageMargins;
   header?: EditorBlockNode[];
   footer?: EditorBlockNode[];
+}
+
+interface PdfExportContext extends PdfParagraphTextContext {
+  fontRegistry: PdfFontRegistry;
 }
 
 function pxToPt(value: number): number {
@@ -161,10 +163,16 @@ function drawLineFragment(
   fragment: PdfParagraphFragment,
   lineX: number,
   y: number,
+  context: PdfExportContext,
 ): void {
   const run = fragment.run;
   const x = lineX + fragment.x;
   const color = run.styles?.color ?? "#111827";
+  const fontFace = context.fontRegistry.resolveFontFace({
+    fontFamily: run.styles?.fontFamily,
+    bold: run.styles?.bold,
+    italic: run.styles?.italic,
+  });
   drawTextHighlight(writer, pageIndex, x, y, fragment.width, fragment.fontSize, run);
   writer.drawText(pageIndex, {
     x,
@@ -174,6 +182,7 @@ function drawLineFragment(
     color,
     bold: run.styles?.bold,
     italic: run.styles?.italic,
+    fontResourceName: fontFace.writerResourceName,
   });
   drawTextDecorations(writer, pageIndex, x, y, fragment.width, fragment.fontSize, color, run);
 }
@@ -186,6 +195,7 @@ function drawParagraphLine(
   contentLeft: number,
   contentWidth: number,
   y: number,
+  context: PdfExportContext,
 ): void {
   const lineX = resolveParagraphX(paragraph, contentLeft, contentWidth, line.width);
   if (line.fragments.length === 0) {
@@ -195,12 +205,13 @@ function drawParagraphLine(
       text: " ",
       fontSize: DEFAULT_FONT_SIZE_PT,
       color: "#111827",
+      fontResourceName: context.fontRegistry.resolveFontFace({}).writerResourceName,
     });
     return;
   }
 
   for (const fragment of line.fragments) {
-    drawLineFragment(writer, pageIndex, fragment, lineX, y);
+    drawLineFragment(writer, pageIndex, fragment, lineX, y, context);
   }
 }
 
@@ -247,7 +258,7 @@ function drawListPrefix(
   prefix: string | null,
   paragraphX: number,
   y: number,
-  context: PdfParagraphTextContext,
+  context: PdfExportContext,
 ): void {
   if (!prefix) {
     return;
@@ -259,6 +270,7 @@ function drawListPrefix(
     text: prefix,
     fontSize: DEFAULT_FONT_SIZE_PT,
     color: "#111827",
+    fontResourceName: context.fontRegistry.resolveFontFace({}).writerResourceName,
   });
 }
 
@@ -269,7 +281,7 @@ function drawBlockParagraphs(
   x: number,
   y: number,
   contentWidth: number,
-  context: PdfParagraphTextContext,
+  context: PdfExportContext,
 ): void {
   if (!blocks || blocks.length === 0) {
     return;
@@ -291,7 +303,7 @@ function drawBlockParagraphs(
       pxToPt,
     });
     for (const line of layout.lines) {
-      drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY);
+      drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY, context);
       cursorY += line.height;
     }
     cursorY += styleLengthToPt(block.style?.spacingAfter);
@@ -313,16 +325,18 @@ function drawSectionHeaderFooter(
   page: PdfHeaderFooterPage,
   totalPages: number,
   measurer: PdfTextMeasurer,
+  fontRegistry: PdfFontRegistry,
 ): void {
   const marginLeft = pxToPt(page.margins.left + page.margins.gutter);
   const marginRight = pxToPt(page.margins.right);
   const contentWidth = Math.max(1, page.width - marginLeft - marginRight);
   const headerY = Math.max(56, pxToPt(page.margins.header));
   const footerY = Math.min(Math.max(headerY + DEFAULT_LINE_HEIGHT_PT, page.height - pxToPt(page.margins.footer)), page.height - 18);
-  const context: PdfParagraphTextContext = {
+  const context: PdfExportContext = {
     pageNumber: page.pageIndex + 1,
     totalPages,
     measurer,
+    fontRegistry,
   };
 
   drawBlockParagraphs(writer, page.pageIndex, page.header, marginLeft, headerY, contentWidth, context);
@@ -336,7 +350,8 @@ function addSectionPage(writer: OasisPdfWriter, width: number, height: number): 
 }
 
 export async function exportEditorDocumentToPdf(document: EditorDocument): Promise<ArrayBuffer> {
-  const writer = new OasisPdfWriter();
+  const fontRegistry = new PdfFontRegistry();
+  const writer = new OasisPdfWriter(fontRegistry.getPdfFontResources());
   const measurer = new PdfTextMeasurer();
   const sections = getDocumentSections(document);
   const headerFooterPages: PdfHeaderFooterPage[] = [];
@@ -367,7 +382,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
         continue;
       }
 
-      const context = { pageNumber: pageIndex + 1, totalPages: 0, measurer };
+      const context: PdfExportContext = { pageNumber: pageIndex + 1, totalPages: 0, measurer, fontRegistry };
       const horizontal = resolveParagraphHorizontalMetrics(block, marginLeft, contentWidth);
       const layout = layoutPdfParagraph({
         paragraph: block,
@@ -394,12 +409,12 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
           cursorY = Math.max(64, marginTop);
         }
 
-        const lineContext = { pageNumber: pageIndex + 1, totalPages: 0, measurer };
+        const lineContext: PdfExportContext = { pageNumber: pageIndex + 1, totalPages: 0, measurer, fontRegistry };
         const lineX = resolveParagraphX(block, horizontal.left, horizontal.width, line.width);
         if (lineIndex === 0) {
           drawListPrefix(writer, pageIndex, prefix, lineX, cursorY, lineContext);
         }
-        drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY);
+        drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY, lineContext);
         cursorY += line.height;
       }
       cursorY += styleLengthToPt(block.style?.spacingAfter);
@@ -413,7 +428,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
 
   const totalPages = writer.getPageCount();
   for (const page of headerFooterPages) {
-    drawSectionHeaderFooter(writer, page, totalPages, measurer);
+    drawSectionHeaderFooter(writer, page, totalPages, measurer, fontRegistry);
   }
 
   return writer.toArrayBuffer();

--- a/src/export/pdf/exportEditorDocumentToPdf.ts
+++ b/src/export/pdf/exportEditorDocumentToPdf.ts
@@ -7,12 +7,12 @@ import type {
   EditorTextRun,
 } from "../../core/model.js";
 import { getDocumentSections } from "../../core/model.js";
+import { PdfTextMeasurer } from "./layout/PdfTextMeasurer.js";
 import { OasisPdfWriter } from "./OasisPdfWriter.js";
 
 const PX_TO_PT = 72 / 96;
 const DEFAULT_FONT_SIZE_PT = 11.25;
 const DEFAULT_LINE_HEIGHT_PT = 16;
-const HELVETICA_AVERAGE_GLYPH_WIDTH = 0.52;
 const LIST_INDENT_PT = 18;
 const LIST_PREFIX_GAP_PT = 6;
 
@@ -23,6 +23,7 @@ interface PdfListState {
 interface PdfTextContext {
   pageNumber: number;
   totalPages: number;
+  measurer: PdfTextMeasurer;
 }
 
 interface PdfHeaderFooterPage {
@@ -45,10 +46,6 @@ function styleLengthToPt(value: number | null | undefined): number {
   return value !== undefined && value !== null ? pxToPt(value) : 0;
 }
 
-function estimateTextWidthPt(text: string, fontSize: number): number {
-  return text.length * fontSize * HELVETICA_AVERAGE_GLYPH_WIDTH;
-}
-
 function runText(run: EditorTextRun, context: PdfTextContext): string {
   if (run.field) {
     return run.field.type === "NUMPAGES" ? String(context.totalPages) : String(context.pageNumber);
@@ -65,13 +62,30 @@ function runFontSizePt(run: EditorTextRun): number {
     : DEFAULT_FONT_SIZE_PT;
 }
 
+function measureRunTextWidthPt(run: EditorTextRun, text: string, context: PdfTextContext): number {
+  return context.measurer.measureTextWidth({
+    text,
+    fontFamily: run.styles?.fontFamily,
+    fontSize: runFontSizePt(run),
+    bold: run.styles?.bold,
+    italic: run.styles?.italic,
+  });
+}
+
+function measurePlainTextWidthPt(text: string, fontSize: number, context: PdfTextContext): number {
+  return context.measurer.measureTextWidth({
+    text,
+    fontSize,
+  });
+}
+
 function estimateParagraphWidthPt(paragraph: EditorParagraphNode, context: PdfTextContext): number {
   return paragraph.runs.reduce((width, run) => {
     const text = runText(run, context);
     if (text.length === 0) {
       return width;
     }
-    return width + estimateTextWidthPt(text, runFontSizePt(run));
+    return width + measureRunTextWidthPt(run, text, context);
   }, 0);
 }
 
@@ -194,7 +208,7 @@ function drawParagraphRuns(
 
     const fontSize = runFontSizePt(run);
     const color = run.styles?.color ?? "#111827";
-    const textWidth = estimateTextWidthPt(text, fontSize);
+    const textWidth = measureRunTextWidthPt(run, text, context);
     drawTextHighlight(writer, pageIndex, cursorX, y, textWidth, fontSize, run);
     writer.drawText(pageIndex, {
       x: cursorX,
@@ -265,6 +279,7 @@ function drawListPrefix(
   listState: PdfListState,
   paragraphX: number,
   y: number,
+  context: PdfTextContext,
 ): void {
   const prefix = resolveListPrefix(paragraph, listState);
   if (!prefix) {
@@ -272,7 +287,7 @@ function drawListPrefix(
   }
 
   writer.drawText(pageIndex, {
-    x: Math.max(0, paragraphX - LIST_PREFIX_GAP_PT - estimateTextWidthPt(prefix, DEFAULT_FONT_SIZE_PT)),
+    x: Math.max(0, paragraphX - LIST_PREFIX_GAP_PT - measurePlainTextWidthPt(prefix, DEFAULT_FONT_SIZE_PT, context)),
     y,
     text: prefix,
     fontSize: DEFAULT_FONT_SIZE_PT,
@@ -320,6 +335,7 @@ function drawSectionHeaderFooter(
   writer: OasisPdfWriter,
   page: PdfHeaderFooterPage,
   totalPages: number,
+  measurer: PdfTextMeasurer,
 ): void {
   const marginLeft = pxToPt(page.margins.left + page.margins.gutter);
   const marginRight = pxToPt(page.margins.right);
@@ -329,6 +345,7 @@ function drawSectionHeaderFooter(
   const context: PdfTextContext = {
     pageNumber: page.pageIndex + 1,
     totalPages,
+    measurer,
   };
 
   drawBlockParagraphs(writer, page.pageIndex, page.header, marginLeft, headerY, contentWidth, context);
@@ -343,6 +360,7 @@ function addSectionPage(writer: OasisPdfWriter, width: number, height: number): 
 
 export async function exportEditorDocumentToPdf(document: EditorDocument): Promise<ArrayBuffer> {
   const writer = new OasisPdfWriter();
+  const measurer = new PdfTextMeasurer();
   const sections = getDocumentSections(document);
   const headerFooterPages: PdfHeaderFooterPage[] = [];
 
@@ -386,10 +404,10 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
         cursorY = Math.max(64, marginTop) + styleLengthToPt(block.style?.spacingBefore);
       }
 
-      const context = { pageNumber: pageIndex + 1, totalPages: 0 };
+      const context = { pageNumber: pageIndex + 1, totalPages: 0, measurer };
       const horizontal = resolveParagraphHorizontalMetrics(block, marginLeft, contentWidth);
       const paragraphX = resolveParagraphX(block, horizontal.left, horizontal.width, context);
-      drawListPrefix(writer, pageIndex, block, listState, paragraphX, cursorY);
+      drawListPrefix(writer, pageIndex, block, listState, paragraphX, cursorY, context);
       drawParagraphRuns(
         writer,
         pageIndex,
@@ -409,7 +427,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
 
   const totalPages = writer.getPageCount();
   for (const page of headerFooterPages) {
-    drawSectionHeaderFooter(writer, page, totalPages);
+    drawSectionHeaderFooter(writer, page, totalPages, measurer);
   }
 
   return writer.toArrayBuffer();

--- a/src/export/pdf/exportEditorDocumentToPdf.ts
+++ b/src/export/pdf/exportEditorDocumentToPdf.ts
@@ -1,0 +1,461 @@
+import type {
+  EditorBlockNode,
+  EditorDocument,
+  EditorPageMargins,
+  EditorParagraphListStyle,
+  EditorParagraphNode,
+  EditorTextRun,
+} from "../../core/model.js";
+import { getDocumentSections } from "../../core/model.js";
+import { OasisPdfWriter } from "./OasisPdfWriter.js";
+
+const PX_TO_PT = 72 / 96;
+const DEFAULT_FONT_SIZE_PT = 11.25;
+const DEFAULT_LINE_HEIGHT_PT = 16;
+const HELVETICA_AVERAGE_GLYPH_WIDTH = 0.52;
+const LIST_INDENT_PT = 18;
+const LIST_PREFIX_GAP_PT = 6;
+
+interface PdfListState {
+  orderedCounters: Map<string, number>;
+}
+
+interface PdfTextContext {
+  pageNumber: number;
+  totalPages: number;
+}
+
+interface PdfHeaderFooterPage {
+  pageIndex: number;
+  width: number;
+  height: number;
+  margins: EditorPageMargins;
+  header?: EditorBlockNode[];
+  footer?: EditorBlockNode[];
+}
+
+function pxToPt(value: number): number {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+  return value * PX_TO_PT;
+}
+
+function styleLengthToPt(value: number | null | undefined): number {
+  return value !== undefined && value !== null ? pxToPt(value) : 0;
+}
+
+function estimateTextWidthPt(text: string, fontSize: number): number {
+  return text.length * fontSize * HELVETICA_AVERAGE_GLYPH_WIDTH;
+}
+
+function runText(run: EditorTextRun, context: PdfTextContext): string {
+  if (run.field) {
+    return run.field.type === "NUMPAGES" ? String(context.totalPages) : String(context.pageNumber);
+  }
+  if (run.image) {
+    return "";
+  }
+  return run.text;
+}
+
+function runFontSizePt(run: EditorTextRun): number {
+  return run.styles?.fontSize !== undefined && run.styles.fontSize !== null
+    ? pxToPt(run.styles.fontSize)
+    : DEFAULT_FONT_SIZE_PT;
+}
+
+function estimateParagraphWidthPt(paragraph: EditorParagraphNode, context: PdfTextContext): number {
+  return paragraph.runs.reduce((width, run) => {
+    const text = runText(run, context);
+    if (text.length === 0) {
+      return width;
+    }
+    return width + estimateTextWidthPt(text, runFontSizePt(run));
+  }, 0);
+}
+
+function resolveParagraphX(
+  paragraph: EditorParagraphNode,
+  contentLeft: number,
+  contentWidth: number,
+  context: PdfTextContext,
+): number {
+  const paragraphWidth = estimateParagraphWidthPt(paragraph, context);
+  if (paragraphWidth <= 0) {
+    return contentLeft;
+  }
+
+  switch (paragraph.style?.align) {
+    case "center":
+      return contentLeft + Math.max(0, (contentWidth - paragraphWidth) / 2);
+    case "right":
+      return contentLeft + Math.max(0, contentWidth - paragraphWidth);
+    case "justify":
+    case "left":
+    default:
+      return contentLeft;
+  }
+}
+
+function resolveParagraphHorizontalMetrics(
+  paragraph: EditorParagraphNode,
+  marginLeft: number,
+  contentWidth: number,
+): { left: number; width: number } {
+  const indentLeft = styleLengthToPt(paragraph.style?.indentLeft);
+  const indentRight = styleLengthToPt(paragraph.style?.indentRight);
+  const firstLineOffset =
+    styleLengthToPt(paragraph.style?.indentFirstLine) - styleLengthToPt(paragraph.style?.indentHanging);
+  const listOffset = paragraph.list ? LIST_INDENT_PT * ((paragraph.list.level ?? 0) + 1) : 0;
+  const left = marginLeft + indentLeft + firstLineOffset + listOffset;
+  const width = Math.max(
+    1,
+    contentWidth - indentLeft - indentRight - Math.max(0, firstLineOffset) - listOffset,
+  );
+  return { left, width };
+}
+
+function drawTextHighlight(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  x: number,
+  y: number,
+  width: number,
+  fontSize: number,
+  run: EditorTextRun,
+): void {
+  if (!run.styles?.highlight || width <= 0) {
+    return;
+  }
+
+  writer.drawRect(pageIndex, {
+    x,
+    y: y - fontSize * 0.82,
+    width,
+    height: fontSize,
+    fill: run.styles.highlight,
+  });
+}
+
+function drawTextDecorations(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  x: number,
+  y: number,
+  width: number,
+  fontSize: number,
+  color: string,
+  run: EditorTextRun,
+): void {
+  if (width <= 0) {
+    return;
+  }
+
+  const lineWidth = Math.max(0.5, fontSize / 18);
+  if (run.styles?.underline) {
+    writer.drawLine(pageIndex, {
+      x1: x,
+      y1: y + fontSize * 0.14,
+      x2: x + width,
+      y2: y + fontSize * 0.14,
+      stroke: color,
+      lineWidth,
+    });
+  }
+  if (run.styles?.strike) {
+    writer.drawLine(pageIndex, {
+      x1: x,
+      y1: y - fontSize * 0.32,
+      x2: x + width,
+      y2: y - fontSize * 0.32,
+      stroke: color,
+      lineWidth,
+    });
+  }
+}
+
+function drawParagraphRuns(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  paragraph: EditorParagraphNode,
+  x: number,
+  y: number,
+  context: PdfTextContext,
+): void {
+  let cursorX = x;
+  let wroteRun = false;
+
+  for (const run of paragraph.runs) {
+    const text = runText(run, context);
+    if (text.length === 0) {
+      continue;
+    }
+
+    const fontSize = runFontSizePt(run);
+    const color = run.styles?.color ?? "#111827";
+    const textWidth = estimateTextWidthPt(text, fontSize);
+    drawTextHighlight(writer, pageIndex, cursorX, y, textWidth, fontSize, run);
+    writer.drawText(pageIndex, {
+      x: cursorX,
+      y,
+      text,
+      fontSize,
+      color,
+      bold: run.styles?.bold,
+      italic: run.styles?.italic,
+    });
+    drawTextDecorations(writer, pageIndex, cursorX, y, textWidth, fontSize, color, run);
+    cursorX += textWidth;
+    wroteRun = true;
+  }
+
+  if (!wroteRun) {
+    writer.drawText(pageIndex, {
+      x,
+      y,
+      text: " ",
+      fontSize: DEFAULT_FONT_SIZE_PT,
+      color: "#111827",
+    });
+  }
+}
+
+function orderedListValueToText(value: number, format: EditorParagraphListStyle["format"]): string {
+  if (format === "lowerLetter" || format === "upperLetter") {
+    const letter = String.fromCharCode(97 + ((value - 1) % 26));
+    return format === "upperLetter" ? letter.toUpperCase() : letter;
+  }
+  return String(value);
+}
+
+function orderedListCounterKey(list: NonNullable<EditorParagraphNode["list"]>): string {
+  return `${list.level ?? 0}:${list.format ?? "decimal"}`;
+}
+
+function resolveListPrefix(paragraph: EditorParagraphNode, listState: PdfListState): string | null {
+  if (!paragraph.list) {
+    listState.orderedCounters.clear();
+    return null;
+  }
+
+  const level = Math.max(0, paragraph.list.level ?? 0);
+  for (const key of Array.from(listState.orderedCounters.keys())) {
+    const keyLevel = Number.parseInt(key.split(":", 1)[0] ?? "0", 10);
+    if (keyLevel > level) {
+      listState.orderedCounters.delete(key);
+    }
+  }
+
+  if (paragraph.list.kind === "bullet") {
+    return "•";
+  }
+
+  const counterKey = orderedListCounterKey(paragraph.list);
+  const previous = listState.orderedCounters.get(counterKey);
+  const next = previous === undefined ? (paragraph.list.startAt ?? 1) : previous + 1;
+  listState.orderedCounters.set(counterKey, next);
+  return `${orderedListValueToText(next, paragraph.list.format)}.`;
+}
+
+function drawListPrefix(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  paragraph: EditorParagraphNode,
+  listState: PdfListState,
+  paragraphX: number,
+  y: number,
+): void {
+  const prefix = resolveListPrefix(paragraph, listState);
+  if (!prefix) {
+    return;
+  }
+
+  writer.drawText(pageIndex, {
+    x: Math.max(0, paragraphX - LIST_PREFIX_GAP_PT - estimateTextWidthPt(prefix, DEFAULT_FONT_SIZE_PT)),
+    y,
+    text: prefix,
+    fontSize: DEFAULT_FONT_SIZE_PT,
+    color: "#111827",
+  });
+}
+
+function drawBlockParagraphs(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  blocks: EditorBlockNode[] | undefined,
+  x: number,
+  y: number,
+  contentWidth: number,
+  context: PdfTextContext,
+): void {
+  if (!blocks || blocks.length === 0) {
+    return;
+  }
+
+  let cursorY = y;
+  for (const block of blocks) {
+    if (block.type !== "paragraph") {
+      continue;
+    }
+    cursorY += styleLengthToPt(block.style?.spacingBefore);
+    const horizontal = resolveParagraphHorizontalMetrics(block, x, contentWidth);
+    const paragraphX = resolveParagraphX(block, horizontal.left, horizontal.width, context);
+    drawParagraphRuns(writer, pageIndex, block, paragraphX, cursorY, context);
+    cursorY += DEFAULT_LINE_HEIGHT_PT + styleLengthToPt(block.style?.spacingAfter);
+  }
+}
+
+function drawDiagnosticPageFrame(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  width: number,
+  height: number,
+  sectionIndex: number,
+): void {
+  writer.drawRect(pageIndex, {
+    x: 0,
+    y: 0,
+    width,
+    height,
+    fill: "#ffffff",
+  });
+  writer.drawRect(pageIndex, {
+    x: 18,
+    y: 18,
+    width: Math.max(1, width - 36),
+    height: Math.max(1, height - 36),
+    stroke: "#d1d5db",
+    lineWidth: 0.75,
+  });
+  writer.drawLine(pageIndex, {
+    x1: 18,
+    y1: 48,
+    x2: Math.max(18, width - 18),
+    y2: 48,
+    stroke: "#e5e7eb",
+    lineWidth: 0.75,
+  });
+  writer.drawText(pageIndex, {
+    x: 24,
+    y: 38,
+    text: `Oasis PDF section ${sectionIndex + 1}`,
+    fontSize: 12,
+    color: "#111827",
+  });
+}
+
+function drawSectionHeaderFooter(
+  writer: OasisPdfWriter,
+  page: PdfHeaderFooterPage,
+  totalPages: number,
+): void {
+  const marginLeft = pxToPt(page.margins.left + page.margins.gutter);
+  const marginRight = pxToPt(page.margins.right);
+  const contentWidth = Math.max(1, page.width - marginLeft - marginRight);
+  const headerY = Math.max(56, pxToPt(page.margins.header));
+  const footerY = Math.min(Math.max(headerY + DEFAULT_LINE_HEIGHT_PT, page.height - pxToPt(page.margins.footer)), page.height - 18);
+  const context: PdfTextContext = {
+    pageNumber: page.pageIndex + 1,
+    totalPages,
+  };
+
+  drawBlockParagraphs(writer, page.pageIndex, page.header, marginLeft, headerY, contentWidth, context);
+  drawBlockParagraphs(writer, page.pageIndex, page.footer, marginLeft, footerY, contentWidth, context);
+}
+
+function addSectionPage(
+  writer: OasisPdfWriter,
+  width: number,
+  height: number,
+  sectionIndex: number,
+): number {
+  const pageIndex = writer.addPage({ width, height });
+  drawDiagnosticPageFrame(writer, pageIndex, width, height, sectionIndex);
+  return pageIndex;
+}
+
+export async function exportEditorDocumentToPdf(document: EditorDocument): Promise<ArrayBuffer> {
+  const writer = new OasisPdfWriter();
+  const sections = getDocumentSections(document);
+  const headerFooterPages: PdfHeaderFooterPage[] = [];
+
+  for (const [sectionIndex, section] of sections.entries()) {
+    const width = Math.max(1, pxToPt(section.pageSettings.width));
+    const height = Math.max(1, pxToPt(section.pageSettings.height));
+    const marginLeft = pxToPt(section.pageSettings.margins.left + section.pageSettings.margins.gutter);
+    const marginRight = pxToPt(section.pageSettings.margins.right);
+    const marginTop = pxToPt(section.pageSettings.margins.top);
+    const marginBottom = pxToPt(section.pageSettings.margins.bottom);
+    const contentWidth = Math.max(1, width - marginLeft - marginRight);
+    const contentBottom = Math.max(marginTop + DEFAULT_LINE_HEIGHT_PT, height - marginBottom);
+    let pageIndex = addSectionPage(writer, width, height, sectionIndex);
+    headerFooterPages.push({
+      pageIndex,
+      width,
+      height,
+      margins: section.pageSettings.margins,
+      header: section.header,
+      footer: section.footer,
+    });
+    const listState: PdfListState = { orderedCounters: new Map() };
+
+    let cursorY = Math.max(64, marginTop);
+    for (const block of section.blocks) {
+      if (block.type !== "paragraph") {
+        continue;
+      }
+
+      cursorY += styleLengthToPt(block.style?.spacingBefore);
+      if (cursorY + DEFAULT_LINE_HEIGHT_PT > contentBottom) {
+        pageIndex = addSectionPage(writer, width, height, sectionIndex);
+        headerFooterPages.push({
+          pageIndex,
+          width,
+          height,
+          margins: section.pageSettings.margins,
+          header: section.header,
+          footer: section.footer,
+        });
+        cursorY = Math.max(64, marginTop) + styleLengthToPt(block.style?.spacingBefore);
+      }
+
+      const context = { pageNumber: pageIndex + 1, totalPages: 0 };
+      const horizontal = resolveParagraphHorizontalMetrics(block, marginLeft, contentWidth);
+      const paragraphX = resolveParagraphX(block, horizontal.left, horizontal.width, context);
+      drawListPrefix(writer, pageIndex, block, listState, paragraphX, cursorY);
+      drawParagraphRuns(
+        writer,
+        pageIndex,
+        block,
+        paragraphX,
+        cursorY,
+        context,
+      );
+      cursorY += DEFAULT_LINE_HEIGHT_PT + styleLengthToPt(block.style?.spacingAfter);
+    }
+  }
+
+  if (writer.getPageCount() === 0) {
+    const pageIndex = writer.addPage({ width: 612, height: 792 });
+    writer.drawText(pageIndex, {
+      x: 24,
+      y: 38,
+      text: "Oasis PDF",
+      fontSize: 12,
+      color: "#111827",
+    });
+  }
+
+  const totalPages = writer.getPageCount();
+  for (const page of headerFooterPages) {
+    drawSectionHeaderFooter(writer, page, totalPages);
+  }
+
+  return writer.toArrayBuffer();
+}
+
+export async function exportEditorDocumentToPdfBlob(document: EditorDocument): Promise<Blob> {
+  const buffer = await exportEditorDocumentToPdf(document);
+  return new Blob([buffer], { type: "application/pdf" });
+}

--- a/src/export/pdf/exportEditorDocumentToPdf.ts
+++ b/src/export/pdf/exportEditorDocumentToPdf.ts
@@ -7,6 +7,15 @@ import type {
   EditorTextRun,
 } from "../../core/model.js";
 import { getDocumentSections } from "../../core/model.js";
+import {
+  layoutPdfParagraph,
+  measurePdfRunTextWidthPt,
+  pdfRunFontSizePt,
+  resolvePdfRunText,
+  type PdfParagraphFragment,
+  type PdfParagraphLine,
+  type PdfParagraphTextContext,
+} from "./layout/layoutParagraph.js";
 import { PdfTextMeasurer } from "./layout/PdfTextMeasurer.js";
 import { OasisPdfWriter } from "./OasisPdfWriter.js";
 
@@ -18,12 +27,6 @@ const LIST_PREFIX_GAP_PT = 6;
 
 interface PdfListState {
   orderedCounters: Map<string, number>;
-}
-
-interface PdfTextContext {
-  pageNumber: number;
-  totalPages: number;
-  measurer: PdfTextMeasurer;
 }
 
 interface PdfHeaderFooterPage {
@@ -46,65 +49,28 @@ function styleLengthToPt(value: number | null | undefined): number {
   return value !== undefined && value !== null ? pxToPt(value) : 0;
 }
 
-function runText(run: EditorTextRun, context: PdfTextContext): string {
-  if (run.field) {
-    return run.field.type === "NUMPAGES" ? String(context.totalPages) : String(context.pageNumber);
-  }
-  if (run.image) {
-    return "";
-  }
-  return run.text;
-}
-
-function runFontSizePt(run: EditorTextRun): number {
-  return run.styles?.fontSize !== undefined && run.styles.fontSize !== null
-    ? pxToPt(run.styles.fontSize)
-    : DEFAULT_FONT_SIZE_PT;
-}
-
-function measureRunTextWidthPt(run: EditorTextRun, text: string, context: PdfTextContext): number {
-  return context.measurer.measureTextWidth({
-    text,
-    fontFamily: run.styles?.fontFamily,
-    fontSize: runFontSizePt(run),
-    bold: run.styles?.bold,
-    italic: run.styles?.italic,
-  });
-}
-
-function measurePlainTextWidthPt(text: string, fontSize: number, context: PdfTextContext): number {
+function measurePlainTextWidthPt(text: string, fontSize: number, context: PdfParagraphTextContext): number {
   return context.measurer.measureTextWidth({
     text,
     fontSize,
   });
 }
 
-function estimateParagraphWidthPt(paragraph: EditorParagraphNode, context: PdfTextContext): number {
-  return paragraph.runs.reduce((width, run) => {
-    const text = runText(run, context);
-    if (text.length === 0) {
-      return width;
-    }
-    return width + measureRunTextWidthPt(run, text, context);
-  }, 0);
-}
-
 function resolveParagraphX(
   paragraph: EditorParagraphNode,
   contentLeft: number,
   contentWidth: number,
-  context: PdfTextContext,
+  lineWidth: number,
 ): number {
-  const paragraphWidth = estimateParagraphWidthPt(paragraph, context);
-  if (paragraphWidth <= 0) {
+  if (lineWidth <= 0) {
     return contentLeft;
   }
 
   switch (paragraph.style?.align) {
     case "center":
-      return contentLeft + Math.max(0, (contentWidth - paragraphWidth) / 2);
+      return contentLeft + Math.max(0, (contentWidth - lineWidth) / 2);
     case "right":
-      return contentLeft + Math.max(0, contentWidth - paragraphWidth);
+      return contentLeft + Math.max(0, contentWidth - lineWidth);
     case "justify":
     case "left":
     default:
@@ -189,49 +155,52 @@ function drawTextDecorations(
   }
 }
 
-function drawParagraphRuns(
+function drawLineFragment(
+  writer: OasisPdfWriter,
+  pageIndex: number,
+  fragment: PdfParagraphFragment,
+  lineX: number,
+  y: number,
+): void {
+  const run = fragment.run;
+  const x = lineX + fragment.x;
+  const color = run.styles?.color ?? "#111827";
+  drawTextHighlight(writer, pageIndex, x, y, fragment.width, fragment.fontSize, run);
+  writer.drawText(pageIndex, {
+    x,
+    y,
+    text: fragment.text,
+    fontSize: fragment.fontSize,
+    color,
+    bold: run.styles?.bold,
+    italic: run.styles?.italic,
+  });
+  drawTextDecorations(writer, pageIndex, x, y, fragment.width, fragment.fontSize, color, run);
+}
+
+function drawParagraphLine(
   writer: OasisPdfWriter,
   pageIndex: number,
   paragraph: EditorParagraphNode,
-  x: number,
+  line: PdfParagraphLine,
+  contentLeft: number,
+  contentWidth: number,
   y: number,
-  context: PdfTextContext,
 ): void {
-  let cursorX = x;
-  let wroteRun = false;
-
-  for (const run of paragraph.runs) {
-    const text = runText(run, context);
-    if (text.length === 0) {
-      continue;
-    }
-
-    const fontSize = runFontSizePt(run);
-    const color = run.styles?.color ?? "#111827";
-    const textWidth = measureRunTextWidthPt(run, text, context);
-    drawTextHighlight(writer, pageIndex, cursorX, y, textWidth, fontSize, run);
+  const lineX = resolveParagraphX(paragraph, contentLeft, contentWidth, line.width);
+  if (line.fragments.length === 0) {
     writer.drawText(pageIndex, {
-      x: cursorX,
-      y,
-      text,
-      fontSize,
-      color,
-      bold: run.styles?.bold,
-      italic: run.styles?.italic,
-    });
-    drawTextDecorations(writer, pageIndex, cursorX, y, textWidth, fontSize, color, run);
-    cursorX += textWidth;
-    wroteRun = true;
-  }
-
-  if (!wroteRun) {
-    writer.drawText(pageIndex, {
-      x,
+      x: lineX,
       y,
       text: " ",
       fontSize: DEFAULT_FONT_SIZE_PT,
       color: "#111827",
     });
+    return;
+  }
+
+  for (const fragment of line.fragments) {
+    drawLineFragment(writer, pageIndex, fragment, lineX, y);
   }
 }
 
@@ -275,13 +244,11 @@ function resolveListPrefix(paragraph: EditorParagraphNode, listState: PdfListSta
 function drawListPrefix(
   writer: OasisPdfWriter,
   pageIndex: number,
-  paragraph: EditorParagraphNode,
-  listState: PdfListState,
+  prefix: string | null,
   paragraphX: number,
   y: number,
-  context: PdfTextContext,
+  context: PdfParagraphTextContext,
 ): void {
-  const prefix = resolveListPrefix(paragraph, listState);
   if (!prefix) {
     return;
   }
@@ -302,7 +269,7 @@ function drawBlockParagraphs(
   x: number,
   y: number,
   contentWidth: number,
-  context: PdfTextContext,
+  context: PdfParagraphTextContext,
 ): void {
   if (!blocks || blocks.length === 0) {
     return;
@@ -315,9 +282,19 @@ function drawBlockParagraphs(
     }
     cursorY += styleLengthToPt(block.style?.spacingBefore);
     const horizontal = resolveParagraphHorizontalMetrics(block, x, contentWidth);
-    const paragraphX = resolveParagraphX(block, horizontal.left, horizontal.width, context);
-    drawParagraphRuns(writer, pageIndex, block, paragraphX, cursorY, context);
-    cursorY += DEFAULT_LINE_HEIGHT_PT + styleLengthToPt(block.style?.spacingAfter);
+    const layout = layoutPdfParagraph({
+      paragraph: block,
+      maxWidth: horizontal.width,
+      context,
+      defaultFontSize: DEFAULT_FONT_SIZE_PT,
+      defaultLineHeight: DEFAULT_LINE_HEIGHT_PT,
+      pxToPt,
+    });
+    for (const line of layout.lines) {
+      drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY);
+      cursorY += line.height;
+    }
+    cursorY += styleLengthToPt(block.style?.spacingAfter);
   }
 }
 
@@ -342,7 +319,7 @@ function drawSectionHeaderFooter(
   const contentWidth = Math.max(1, page.width - marginLeft - marginRight);
   const headerY = Math.max(56, pxToPt(page.margins.header));
   const footerY = Math.min(Math.max(headerY + DEFAULT_LINE_HEIGHT_PT, page.height - pxToPt(page.margins.footer)), page.height - 18);
-  const context: PdfTextContext = {
+  const context: PdfParagraphTextContext = {
     pageNumber: page.pageIndex + 1,
     totalPages,
     measurer,
@@ -390,33 +367,42 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
         continue;
       }
 
-      cursorY += styleLengthToPt(block.style?.spacingBefore);
-      if (cursorY + DEFAULT_LINE_HEIGHT_PT > contentBottom) {
-        pageIndex = addSectionPage(writer, width, height);
-        headerFooterPages.push({
-          pageIndex,
-          width,
-          height,
-          margins: section.pageSettings.margins,
-          header: section.header,
-          footer: section.footer,
-        });
-        cursorY = Math.max(64, marginTop) + styleLengthToPt(block.style?.spacingBefore);
-      }
-
       const context = { pageNumber: pageIndex + 1, totalPages: 0, measurer };
       const horizontal = resolveParagraphHorizontalMetrics(block, marginLeft, contentWidth);
-      const paragraphX = resolveParagraphX(block, horizontal.left, horizontal.width, context);
-      drawListPrefix(writer, pageIndex, block, listState, paragraphX, cursorY, context);
-      drawParagraphRuns(
-        writer,
-        pageIndex,
-        block,
-        paragraphX,
-        cursorY,
+      const layout = layoutPdfParagraph({
+        paragraph: block,
+        maxWidth: horizontal.width,
         context,
-      );
-      cursorY += DEFAULT_LINE_HEIGHT_PT + styleLengthToPt(block.style?.spacingAfter);
+        defaultFontSize: DEFAULT_FONT_SIZE_PT,
+        defaultLineHeight: DEFAULT_LINE_HEIGHT_PT,
+        pxToPt,
+      });
+      const prefix = resolveListPrefix(block, listState);
+
+      cursorY += styleLengthToPt(block.style?.spacingBefore);
+      for (const [lineIndex, line] of layout.lines.entries()) {
+        if (cursorY + line.height > contentBottom) {
+          pageIndex = addSectionPage(writer, width, height);
+          headerFooterPages.push({
+            pageIndex,
+            width,
+            height,
+            margins: section.pageSettings.margins,
+            header: section.header,
+            footer: section.footer,
+          });
+          cursorY = Math.max(64, marginTop);
+        }
+
+        const lineContext = { pageNumber: pageIndex + 1, totalPages: 0, measurer };
+        const lineX = resolveParagraphX(block, horizontal.left, horizontal.width, line.width);
+        if (lineIndex === 0) {
+          drawListPrefix(writer, pageIndex, prefix, lineX, cursorY, lineContext);
+        }
+        drawParagraphLine(writer, pageIndex, block, line, horizontal.left, horizontal.width, cursorY);
+        cursorY += line.height;
+      }
+      cursorY += styleLengthToPt(block.style?.spacingAfter);
     }
   }
 

--- a/src/export/pdf/exportEditorDocumentToPdf.ts
+++ b/src/export/pdf/exportEditorDocumentToPdf.ts
@@ -306,42 +306,13 @@ function drawBlockParagraphs(
   }
 }
 
-function drawDiagnosticPageFrame(
-  writer: OasisPdfWriter,
-  pageIndex: number,
-  width: number,
-  height: number,
-  sectionIndex: number,
-): void {
+function drawPageBackground(writer: OasisPdfWriter, pageIndex: number, width: number, height: number): void {
   writer.drawRect(pageIndex, {
     x: 0,
     y: 0,
     width,
     height,
     fill: "#ffffff",
-  });
-  writer.drawRect(pageIndex, {
-    x: 18,
-    y: 18,
-    width: Math.max(1, width - 36),
-    height: Math.max(1, height - 36),
-    stroke: "#d1d5db",
-    lineWidth: 0.75,
-  });
-  writer.drawLine(pageIndex, {
-    x1: 18,
-    y1: 48,
-    x2: Math.max(18, width - 18),
-    y2: 48,
-    stroke: "#e5e7eb",
-    lineWidth: 0.75,
-  });
-  writer.drawText(pageIndex, {
-    x: 24,
-    y: 38,
-    text: `Oasis PDF section ${sectionIndex + 1}`,
-    fontSize: 12,
-    color: "#111827",
   });
 }
 
@@ -364,14 +335,9 @@ function drawSectionHeaderFooter(
   drawBlockParagraphs(writer, page.pageIndex, page.footer, marginLeft, footerY, contentWidth, context);
 }
 
-function addSectionPage(
-  writer: OasisPdfWriter,
-  width: number,
-  height: number,
-  sectionIndex: number,
-): number {
+function addSectionPage(writer: OasisPdfWriter, width: number, height: number): number {
   const pageIndex = writer.addPage({ width, height });
-  drawDiagnosticPageFrame(writer, pageIndex, width, height, sectionIndex);
+  drawPageBackground(writer, pageIndex, width, height);
   return pageIndex;
 }
 
@@ -380,7 +346,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
   const sections = getDocumentSections(document);
   const headerFooterPages: PdfHeaderFooterPage[] = [];
 
-  for (const [sectionIndex, section] of sections.entries()) {
+  for (const section of sections) {
     const width = Math.max(1, pxToPt(section.pageSettings.width));
     const height = Math.max(1, pxToPt(section.pageSettings.height));
     const marginLeft = pxToPt(section.pageSettings.margins.left + section.pageSettings.margins.gutter);
@@ -389,7 +355,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
     const marginBottom = pxToPt(section.pageSettings.margins.bottom);
     const contentWidth = Math.max(1, width - marginLeft - marginRight);
     const contentBottom = Math.max(marginTop + DEFAULT_LINE_HEIGHT_PT, height - marginBottom);
-    let pageIndex = addSectionPage(writer, width, height, sectionIndex);
+    let pageIndex = addSectionPage(writer, width, height);
     headerFooterPages.push({
       pageIndex,
       width,
@@ -408,7 +374,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
 
       cursorY += styleLengthToPt(block.style?.spacingBefore);
       if (cursorY + DEFAULT_LINE_HEIGHT_PT > contentBottom) {
-        pageIndex = addSectionPage(writer, width, height, sectionIndex);
+        pageIndex = addSectionPage(writer, width, height);
         headerFooterPages.push({
           pageIndex,
           width,
@@ -438,13 +404,7 @@ export async function exportEditorDocumentToPdf(document: EditorDocument): Promi
 
   if (writer.getPageCount() === 0) {
     const pageIndex = writer.addPage({ width: 612, height: 792 });
-    writer.drawText(pageIndex, {
-      x: 24,
-      y: 38,
-      text: "Oasis PDF",
-      fontSize: 12,
-      color: "#111827",
-    });
+    drawPageBackground(writer, pageIndex, 612, 792);
   }
 
   const totalPages = writer.getPageCount();

--- a/src/export/pdf/fonts/PdfFontRegistry.ts
+++ b/src/export/pdf/fonts/PdfFontRegistry.ts
@@ -1,0 +1,95 @@
+import type { OasisPdfFontResource } from "../OasisPdfWriter.js";
+
+export interface PdfFontResolveOptions {
+  fontFamily?: string | null;
+  bold?: boolean | null;
+  italic?: boolean | null;
+}
+
+export interface PdfRegisteredFontFace {
+  key: string;
+  family: string;
+  bold: boolean;
+  italic: boolean;
+  writerResourceName: string;
+  pdfResource: OasisPdfFontResource;
+}
+
+const BASE14_HELVETICA_FACES: PdfRegisteredFontFace[] = [
+  {
+    key: "helvetica:regular",
+    family: "Helvetica",
+    bold: false,
+    italic: false,
+    writerResourceName: "F1",
+    pdfResource: { kind: "base14", resourceName: "F1", baseFont: "Helvetica" },
+  },
+  {
+    key: "helvetica:bold",
+    family: "Helvetica",
+    bold: true,
+    italic: false,
+    writerResourceName: "F2",
+    pdfResource: { kind: "base14", resourceName: "F2", baseFont: "Helvetica-Bold" },
+  },
+  {
+    key: "helvetica:italic",
+    family: "Helvetica",
+    bold: false,
+    italic: true,
+    writerResourceName: "F3",
+    pdfResource: { kind: "base14", resourceName: "F3", baseFont: "Helvetica-Oblique" },
+  },
+  {
+    key: "helvetica:bolditalic",
+    family: "Helvetica",
+    bold: true,
+    italic: true,
+    writerResourceName: "F4",
+    pdfResource: { kind: "base14", resourceName: "F4", baseFont: "Helvetica-BoldOblique" },
+  },
+];
+
+function normalizeFamily(fontFamily: string | null | undefined): string {
+  const firstFamily = (fontFamily ?? "Helvetica").split(",")[0]?.trim().replace(/^['\"]|['\"]$/g, "");
+  return firstFamily && firstFamily.length > 0 ? firstFamily : "Helvetica";
+}
+
+function faceKey(family: string, bold: boolean, italic: boolean): string {
+  return `${family.toLowerCase()}:${bold ? "bold" : "regular"}${italic ? "italic" : ""}`;
+}
+
+export class PdfFontRegistry {
+  private readonly faces = new Map<string, PdfRegisteredFontFace>();
+  private readonly fallbackFamily = "Helvetica";
+
+  constructor() {
+    for (const face of BASE14_HELVETICA_FACES) {
+      this.registerFontFace(face);
+    }
+  }
+
+  registerFontFace(face: PdfRegisteredFontFace): void {
+    this.faces.set(faceKey(face.family, face.bold, face.italic), face);
+  }
+
+  resolveFontFace(options: PdfFontResolveOptions): PdfRegisteredFontFace {
+    const family = normalizeFamily(options.fontFamily);
+    const bold = Boolean(options.bold);
+    const italic = Boolean(options.italic);
+
+    return (
+      this.faces.get(faceKey(family, bold, italic)) ??
+      this.faces.get(faceKey(this.fallbackFamily, bold, italic)) ??
+      this.faces.get(faceKey(this.fallbackFamily, false, false))!
+    );
+  }
+
+  getPdfFontResources(): OasisPdfFontResource[] {
+    const resources = new Map<string, OasisPdfFontResource>();
+    for (const face of this.faces.values()) {
+      resources.set(face.pdfResource.resourceName, face.pdfResource);
+    }
+    return Array.from(resources.values());
+  }
+}

--- a/src/export/pdf/layout/PdfTextMeasurer.ts
+++ b/src/export/pdf/layout/PdfTextMeasurer.ts
@@ -1,0 +1,205 @@
+export interface PdfTextMeasureOptions {
+  text: string;
+  fontFamily?: string | null;
+  fontSize: number;
+  bold?: boolean;
+  italic?: boolean;
+}
+
+export interface PdfGlyphMeasurement {
+  char: string;
+  codePoint: number;
+  x: number;
+  width: number;
+  advance: number;
+}
+
+export interface PdfTextMeasurement {
+  width: number;
+  glyphs: PdfGlyphMeasurement[];
+}
+
+const WIDTH_UNITS_PER_EM = 1000;
+
+// Widths are PDF Type 1 Helvetica-compatible glyph widths in 1/1000 em units
+// for the ASCII range the current writer can reliably encode. Unknown glyphs
+// intentionally go through a deterministic fallback so layout stays O(n) and
+// stable until embedded fonts / full shaping are introduced.
+const HELVETICA_WIDTHS: Record<string, number> = {
+  " ": 278,
+  "!": 278,
+  '"': 355,
+  "#": 556,
+  "$": 556,
+  "%": 889,
+  "&": 667,
+  "'": 191,
+  "(": 333,
+  ")": 333,
+  "*": 389,
+  "+": 584,
+  ",": 278,
+  "-": 333,
+  ".": 278,
+  "/": 278,
+  "0": 556,
+  "1": 556,
+  "2": 556,
+  "3": 556,
+  "4": 556,
+  "5": 556,
+  "6": 556,
+  "7": 556,
+  "8": 556,
+  "9": 556,
+  ":": 278,
+  ";": 278,
+  "<": 584,
+  "=": 584,
+  ">": 584,
+  "?": 556,
+  "@": 1015,
+  A: 667,
+  B: 667,
+  C: 722,
+  D: 722,
+  E: 667,
+  F: 611,
+  G: 778,
+  H: 722,
+  I: 278,
+  J: 500,
+  K: 667,
+  L: 556,
+  M: 833,
+  N: 722,
+  O: 778,
+  P: 667,
+  Q: 778,
+  R: 722,
+  S: 667,
+  T: 611,
+  U: 722,
+  V: 667,
+  W: 944,
+  X: 667,
+  Y: 667,
+  Z: 611,
+  "[": 278,
+  "\\": 278,
+  "]": 278,
+  "^": 469,
+  _: 556,
+  "`": 333,
+  a: 556,
+  b: 556,
+  c: 500,
+  d: 556,
+  e: 556,
+  f: 278,
+  g: 556,
+  h: 556,
+  i: 222,
+  j: 222,
+  k: 500,
+  l: 222,
+  m: 833,
+  n: 556,
+  o: 556,
+  p: 556,
+  q: 556,
+  r: 333,
+  s: 500,
+  t: 278,
+  u: 556,
+  v: 500,
+  w: 722,
+  x: 500,
+  y: 500,
+  z: 500,
+  "{": 334,
+  "|": 260,
+  "}": 334,
+  "~": 584,
+};
+
+const SYMBOL_WIDTHS: Record<string, number> = {
+  "•": 350,
+  "○": 600,
+  "▪": 350,
+};
+
+function fallbackGlyphWidthUnits(char: string): number {
+  const codePoint = char.codePointAt(0) ?? 0;
+
+  if (/\s/u.test(char)) {
+    return 278;
+  }
+  if (codePoint >= 0x300 && codePoint <= 0x36f) {
+    return 0;
+  }
+  if (codePoint >= 0x4e00 && codePoint <= 0x9fff) {
+    return 1000;
+  }
+  if (codePoint > 0xffff) {
+    return 1000;
+  }
+  return 556;
+}
+
+function glyphWidthUnits(char: string): number {
+  return HELVETICA_WIDTHS[char] ?? SYMBOL_WIDTHS[char] ?? fallbackGlyphWidthUnits(char);
+}
+
+function cacheKey(options: PdfTextMeasureOptions): string {
+  return [
+    options.fontFamily ?? "Helvetica",
+    options.fontSize,
+    options.bold ? "1" : "0",
+    options.italic ? "1" : "0",
+    options.text,
+  ].join("\u0000");
+}
+
+export class PdfTextMeasurer {
+  private readonly cache = new Map<string, PdfTextMeasurement>();
+
+  measureText(options: PdfTextMeasureOptions): PdfTextMeasurement {
+    if (options.text.length === 0 || options.fontSize <= 0) {
+      return { width: 0, glyphs: [] };
+    }
+
+    const key = cacheKey(options);
+    const cached = this.cache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    let x = 0;
+    const glyphs: PdfGlyphMeasurement[] = [];
+    for (const char of options.text) {
+      const width = (glyphWidthUnits(char) / WIDTH_UNITS_PER_EM) * options.fontSize;
+      const glyph: PdfGlyphMeasurement = {
+        char,
+        codePoint: char.codePointAt(0) ?? 0,
+        x,
+        width,
+        advance: width,
+      };
+      glyphs.push(glyph);
+      x += glyph.advance;
+    }
+
+    const measurement = { width: x, glyphs };
+    this.cache.set(key, measurement);
+    return measurement;
+  }
+
+  measureTextWidth(options: PdfTextMeasureOptions): number {
+    return this.measureText(options).width;
+  }
+
+  getCacheSize(): number {
+    return this.cache.size;
+  }
+}

--- a/src/export/pdf/layout/layoutParagraph.ts
+++ b/src/export/pdf/layout/layoutParagraph.ts
@@ -1,0 +1,218 @@
+import type { EditorParagraphNode, EditorTextRun } from "../../../core/model.js";
+import type { PdfTextMeasurer } from "./PdfTextMeasurer.js";
+
+export interface PdfParagraphTextContext {
+  pageNumber: number;
+  totalPages: number;
+  measurer: PdfTextMeasurer;
+}
+
+export interface PdfParagraphFragment {
+  run: EditorTextRun;
+  text: string;
+  x: number;
+  width: number;
+  fontSize: number;
+}
+
+export interface PdfParagraphLine {
+  fragments: PdfParagraphFragment[];
+  width: number;
+  height: number;
+}
+
+export interface PdfParagraphLayout {
+  lines: PdfParagraphLine[];
+  width: number;
+  height: number;
+}
+
+export interface LayoutPdfParagraphOptions {
+  paragraph: EditorParagraphNode;
+  maxWidth: number;
+  context: PdfParagraphTextContext;
+  defaultFontSize: number;
+  defaultLineHeight: number;
+  pxToPt: (value: number) => number;
+}
+
+interface PdfTextToken {
+  run: EditorTextRun;
+  text: string;
+  width: number;
+  fontSize: number;
+  forcedBreak?: boolean;
+}
+
+const TOKEN_PATTERN = /\n|\S+\s*|\s+/gu;
+
+export function resolvePdfRunText(run: EditorTextRun, context: PdfParagraphTextContext): string {
+  if (run.field) {
+    return run.field.type === "NUMPAGES" ? String(context.totalPages) : String(context.pageNumber);
+  }
+  if (run.image) {
+    return "";
+  }
+  return run.text;
+}
+
+export function pdfRunFontSizePt(
+  run: EditorTextRun,
+  defaultFontSize: number,
+  pxToPt: (value: number) => number,
+): number {
+  return run.styles?.fontSize !== undefined && run.styles.fontSize !== null
+    ? pxToPt(run.styles.fontSize)
+    : defaultFontSize;
+}
+
+export function measurePdfRunTextWidthPt(
+  run: EditorTextRun,
+  text: string,
+  context: PdfParagraphTextContext,
+  defaultFontSize: number,
+  pxToPt: (value: number) => number,
+): number {
+  return context.measurer.measureTextWidth({
+    text,
+    fontFamily: run.styles?.fontFamily,
+    fontSize: pdfRunFontSizePt(run, defaultFontSize, pxToPt),
+    bold: run.styles?.bold,
+    italic: run.styles?.italic,
+  });
+}
+
+function tokenizeRun(
+  run: EditorTextRun,
+  text: string,
+  options: LayoutPdfParagraphOptions,
+): PdfTextToken[] {
+  const tokens: PdfTextToken[] = [];
+  const fontSize = pdfRunFontSizePt(run, options.defaultFontSize, options.pxToPt);
+
+  for (const match of text.matchAll(TOKEN_PATTERN)) {
+    const tokenText = match[0];
+    if (tokenText === "\n") {
+      tokens.push({ run, text: "", width: 0, fontSize, forcedBreak: true });
+      continue;
+    }
+    if (tokenText.length === 0) {
+      continue;
+    }
+
+    tokens.push({
+      run,
+      text: tokenText,
+      width: measurePdfRunTextWidthPt(run, tokenText, options.context, options.defaultFontSize, options.pxToPt),
+      fontSize,
+    });
+  }
+
+  return tokens;
+}
+
+function tokenCreatesVisibleText(token: PdfTextToken): boolean {
+  return token.text.trim().length > 0;
+}
+
+function createLine(tokens: PdfTextToken[], defaultLineHeight: number): PdfParagraphLine {
+  let x = 0;
+  let width = 0;
+  let maxFontSize = 0;
+  const fragments: PdfParagraphFragment[] = [];
+
+  for (const token of tokens) {
+    if (token.text.length === 0) {
+      continue;
+    }
+    fragments.push({
+      run: token.run,
+      text: token.text,
+      x,
+      width: token.width,
+      fontSize: token.fontSize,
+    });
+    x += token.width;
+    width += token.width;
+    maxFontSize = Math.max(maxFontSize, token.fontSize);
+  }
+
+  return {
+    fragments,
+    width,
+    height: Math.max(defaultLineHeight, maxFontSize * 1.2),
+  };
+}
+
+function pushLine(lines: PdfParagraphLine[], tokens: PdfTextToken[], defaultLineHeight: number): void {
+  const withoutLeadingWhitespace = tokens.slice();
+  while (withoutLeadingWhitespace.length > 0 && !tokenCreatesVisibleText(withoutLeadingWhitespace[0]!)) {
+    withoutLeadingWhitespace.shift();
+  }
+
+  const withoutTrailingWhitespace = withoutLeadingWhitespace;
+  while (
+    withoutTrailingWhitespace.length > 0 &&
+    !tokenCreatesVisibleText(withoutTrailingWhitespace[withoutTrailingWhitespace.length - 1]!)
+  ) {
+    withoutTrailingWhitespace.pop();
+  }
+
+  lines.push(createLine(withoutTrailingWhitespace, defaultLineHeight));
+}
+
+export function layoutPdfParagraph(options: LayoutPdfParagraphOptions): PdfParagraphLayout {
+  const maxWidth = Math.max(1, options.maxWidth);
+  const tokens: PdfTextToken[] = [];
+
+  for (const run of options.paragraph.runs) {
+    const text = resolvePdfRunText(run, options.context);
+    if (text.length === 0) {
+      continue;
+    }
+    tokens.push(...tokenizeRun(run, text, options));
+  }
+
+  if (tokens.length === 0) {
+    const emptyLine = createLine([], options.defaultLineHeight);
+    return { lines: [emptyLine], width: 0, height: emptyLine.height };
+  }
+
+  const lines: PdfParagraphLine[] = [];
+  let lineTokens: PdfTextToken[] = [];
+  let lineWidth = 0;
+
+  for (const token of tokens) {
+    if (token.forcedBreak) {
+      pushLine(lines, lineTokens, options.defaultLineHeight);
+      lineTokens = [];
+      lineWidth = 0;
+      continue;
+    }
+
+    if (
+      lineTokens.length > 0 &&
+      tokenCreatesVisibleText(token) &&
+      lineWidth + token.width > maxWidth
+    ) {
+      pushLine(lines, lineTokens, options.defaultLineHeight);
+      lineTokens = [];
+      lineWidth = 0;
+    }
+
+    if (lineTokens.length === 0 && !tokenCreatesVisibleText(token)) {
+      continue;
+    }
+
+    lineTokens.push(token);
+    lineWidth += token.width;
+  }
+
+  if (lineTokens.length > 0 || lines.length === 0) {
+    pushLine(lines, lineTokens, options.defaultLineHeight);
+  }
+
+  const width = lines.reduce((max, line) => Math.max(max, line.width), 0);
+  const height = lines.reduce((sum, line) => sum + line.height, 0);
+  return { lines, width, height };
+}

--- a/src/ui/components/Menubar/defaultMenuItems.ts
+++ b/src/ui/components/Menubar/defaultMenuItems.ts
@@ -6,7 +6,7 @@ export const defaultMenuItems: MenuItem[] = [
   { id: "file_import", path: "File/Import", labelKey: "toolbar.import", shortcut: "Ctrl+O", action: (ctx) => ctx.importInputRef()?.click(), icon: "upload" },
   { id: "file_save", path: "File/Save", labelKey: "generic.save", shortcut: "Ctrl+S", hidden: true, icon: "save" },
   { id: "file_export", path: "File/Export", labelKey: "menu.file.export", icon: "download" },
-  { id: "file_export_pdf", path: "File/Export/PDF", hidden: true },
+  { id: "file_export_pdf", path: "File/Export/PDF", action: (ctx) => void ctx.handleExportPdf(), icon: "file-down" },
   { id: "file_export_docx", path: "File/Export/DOCX", action: (ctx) => void ctx.handleExportDocx(), icon: "file-text" },
   { id: "file_export_html", path: "File/Export/HTML", hidden: true },
   { id: "file_export_md", path: "File/Export/MD", hidden: true },
@@ -64,7 +64,7 @@ export const defaultMenuItems: MenuItem[] = [
 
   // Tools
   { id: "tools_wordcount", path: "Tools/Word count", labelKey: "menu.tools.wordcount", hidden: true },
-  { id: "tools_spelling", path: "Tools/Spelling", hidden: true },
+  { id: "tools_spelling", hidden: true, path: "Tools/Spelling" },
   { id: "tools_preferences", path: "Tools/Preferences", hidden: true },
 
   // Help

--- a/src/ui/components/Toolbar/EditorToolbar.tsx
+++ b/src/ui/components/Toolbar/EditorToolbar.tsx
@@ -56,12 +56,20 @@ export function EditorToolbar(props: {
         <Show when={showFileGroup()}>
           <ToolbarDropdown label="" icon="file" testId="editor-toolbar-file-dropdown" tooltip={t("toolbar.file")}>
             <ToolbarButton
-              icon="download"
-              label={t("toolbar.export")}
+              icon="file-text"
+              label="Export DOCX"
               wide
               data-testid="editor-toolbar-export-docx"
               onClick={() => void ctx().handleExportDocx()}
-              tooltip={t("toolbar.export")}
+              tooltip="Export DOCX"
+            />
+            <ToolbarButton
+              icon="file-down"
+              label="Export PDF"
+              wide
+              data-testid="editor-toolbar-export-pdf"
+              onClick={() => void ctx().handleExportPdf()}
+              tooltip="Export PDF"
             />
             <ToolbarButton
               icon="upload"

--- a/src/ui/components/Toolbar/types.ts
+++ b/src/ui/components/Toolbar/types.ts
@@ -28,7 +28,8 @@ export interface EditorToolbarCtx {
   tableActionRestrictionLabel: () => string | null;
   isInsideTable: () => boolean;
 
-  handleExportDocx: () => void;
+  handleExportDocx: () => void | Promise<void>;
+  handleExportPdf: () => void | Promise<void>;
   toggleFindReplace: (open?: boolean) => void;
   performUndo: () => void;
   performRedo: () => void;


### PR DESCRIPTION
Adds an isolated PDF export pipeline without touching the editor display/canvas/UI.

Includes:
- Minimal OasisPdfWriter
- Editor document PDF export entrypoint
- Cached PDF text measurement
- Linear paragraph wrapping/layout
- Line-based pagination
- Basic inline styles, lists, headers/footers, PAGE and NUMPAGES fields
- Smoke tests for writer/export/layout

Opened as draft to trigger CI while the export pipeline is still being built out.