### PR TITLE
chore: sync PDF branch with main

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,22 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - run: npm install
+
+      - run: npm test
+
+      - run: npm run build:app


### PR DESCRIPTION
Merge main into feat/isolated-pdf-writer so the PDF export branch includes the latest CI workflow commit from main.