### PR TITLE
Perf: Implement structural sharing for document editing

### DIFF
--- a/src/app/controllers/useEditorTableOperations.ts
+++ b/src/app/controllers/useEditorTableOperations.ts
@@ -1172,8 +1172,7 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
     const zone = location.zone;
     const targetBlocks = getTargetBlocks(current, zone);
 
-    const nextBlocks = targetBlocks.map(cloneBlock);
-    const tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
+    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return edit(current);
     }
@@ -1205,7 +1204,19 @@ export function createEditorTableOperations(deps: EditorTableOperationsDeps) {
       (block): block is EditorParagraphNode => block.type === "paragraph",
     );
 
-    targetCell.blocks.splice(0, targetCell.blocks.length, ...replacementParagraphs);
+    const nextBlocks = [...targetBlocks];
+    const newTableBlock = { ...tableBlock };
+    const newRows = [...tableBlock.rows];
+    const newRow = { ...tableBlock.rows[location.rowIndex] };
+    const newCells = [...newRow.cells];
+    const newCell = { ...targetCell };
+
+    newCell.blocks = replacementParagraphs;
+    newCells[location.cellIndex] = newCell;
+    newRow.cells = newCells;
+    newRows[location.rowIndex] = newRow;
+    newTableBlock.rows = newRows;
+    nextBlocks[location.blockIndex] = newTableBlock;
 
     const nextState = updateBlocksInCurrentSection(current, nextBlocks, zone);
     return {

--- a/src/core/commands/utils.ts
+++ b/src/core/commands/utils.ts
@@ -237,21 +237,45 @@ export function replaceParagraphsInBlocks(blocks: EditorBlockNode[], newParagrap
 
   let index = 0;
   const processBlocks = (nodes: EditorBlockNode[]): EditorBlockNode[] => {
-    return nodes.map(node => {
+    let nodesChanged = false;
+    const nextNodes = nodes.map(node => {
       if (node.type === "paragraph") {
-        return newParagraphs[index++] ?? node;
+        const nextPara = newParagraphs[index++];
+        const resultPara = nextPara ?? node;
+        if (resultPara !== node) {
+          nodesChanged = true;
+        }
+        return resultPara;
       }
-      return {
-        ...node,
-        rows: node.rows.map(row => ({
-          ...row,
-          cells: row.cells.map(cell => ({
-            ...cell,
-            blocks: processBlocks(cell.blocks) as EditorParagraphNode[]
-          }))
-        }))
-      };
+      if (node.type === "table") {
+        let rowsChanged = false;
+        const nextRows = node.rows.map(row => {
+          let cellsChanged = false;
+          const nextCells = row.cells.map(cell => {
+            const nextCellBlocks = processBlocks(cell.blocks);
+            if (nextCellBlocks !== cell.blocks) {
+              cellsChanged = true;
+              return { ...cell, blocks: nextCellBlocks as EditorParagraphNode[] };
+            }
+            return cell;
+          });
+
+          if (cellsChanged) {
+            rowsChanged = true;
+            return { ...row, cells: nextCells };
+          }
+          return row;
+        });
+
+        if (rowsChanged) {
+          nodesChanged = true;
+          return { ...node, rows: nextRows };
+        }
+      }
+      return node;
     });
+
+    return nodesChanged ? nextNodes : nodes;
   };
   return processBlocks(blocks);
 }


### PR DESCRIPTION
The editor experienced extreme performance degradation (measured latency upwards of 4 seconds on `input-to-layout`) when performing text operations inside nested structures. This was traced back to document block replacement algorithms inside `useEditorTableOperations.ts` and `src/core/commands/utils.ts`. The original logic was eagerly generating full recursive copies of the entire document subtree regardless of whether blocks were mutated.

I refactored `processBlocks` and `applyTableAwareParagraphEdit` to implement true structural sharing, enabling React/VDOM reconciliation algorithms to rapidly traverse document branches by comparing object references, eliminating the lag on text input. All tests verified properly against regressions.

---
*PR created automatically by Jules for task [2025275277790922084](https://jules.google.com/task/2025275277790922084) started by @celsowm*