### PR TITLE
perf: fix extreme selection drag and typing lag by restoring structural sharing

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,13 +45,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    let tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -104,13 +105,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    let tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
@@ -213,13 +215,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
@@ -273,13 +276,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -63,11 +63,14 @@ export const applyTableAwareParagraphEdit = (
   }
 
   const zone = location.zone;
-  const nextBlocks = getTargetBlocks(current, zone).map(cloneBlock);
-  const tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
+  const nextBlocks = [...getTargetBlocks(current, zone)];
+  let tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
   if (!tableBlock || tableBlock.type !== "table") {
     return edit(current);
   }
+
+  tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+  nextBlocks[location.blockIndex] = tableBlock;
 
   const targetCell =
     tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,13 +47,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -199,13 +200,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1) {
       return current;
@@ -303,13 +305,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -438,13 +441,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    let tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
+
+    tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -107,11 +107,14 @@ export function createTableSelectionAwareCommands(
 
       const tempResult = command(tempState);
       const resultParagraphs = getParagraphs(tempResult);
-      const targetBlocks = deps.getTargetBlocks(current, zone).map(cloneBlock);
-      const tableBlock = targetBlocks[blockIndex] as EditorTableNode;
-      if (!tableBlock) {
+      const targetBlocks = [...deps.getTargetBlocks(current, zone)];
+      let tableBlock = targetBlocks[blockIndex] as EditorTableNode;
+      if (!tableBlock || tableBlock.type !== "table") {
         return current;
       }
+
+      tableBlock = cloneBlock(tableBlock) as EditorTableNode;
+      targetBlocks[blockIndex] = tableBlock;
 
       let paragraphIndex = 0;
       for (let index = 0; index < cells.length; index += 1) {

--- a/src/app/controllers/useEditorHistoryActions.ts
+++ b/src/app/controllers/useEditorHistoryActions.ts
@@ -182,10 +182,7 @@ export function createEditorHistoryActions(deps: UseEditorHistoryActionsProps) {
     const snapshot = deps.stateSnapshot();
     deps.applyHistoryState({
       ...snapshot,
-      document: {
-        ...snapshot.document,
-        sections: snapshot.document.sections?.map(cloneSection),
-      },
+      document: snapshot.document,
       selection: {
         anchor: { ...nextSelection.anchor },
         focus: { ...nextSelection.focus },

--- a/src/ui/OasisEditorApp.tsx
+++ b/src/ui/OasisEditorApp.tsx
@@ -259,7 +259,7 @@ export function OasisEditorApp(props: OasisEditorAppProps = {}) {
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
This PR resolves severe performance issues during typing and selection dragging in the editor. Previously, updating selection or performing a table operation was triggering full deep clones of the document via `cloneEditorState`, `cloneSection`, or `map(cloneBlock)`. This `O(N)` scaling with document size caused massive lag (input-to-layout latencies of ~4.4s). By utilizing shallow copying and targeted cloning of the mutated table block, we maintain structural sharing and restore responsive performance without sacrificing immutability.

---
*PR created automatically by Jules for task [12173178495680571594](https://jules.google.com/task/12173178495680571594) started by @celsowm*