### PR TITLE
perf: optimize table editing structural sharing

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,13 +45,13 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -104,13 +104,13 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
@@ -213,13 +213,13 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
@@ -273,13 +273,13 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -63,11 +63,13 @@ export const applyTableAwareParagraphEdit = (
   }
 
   const zone = location.zone;
-  const nextBlocks = getTargetBlocks(current, zone).map(cloneBlock);
-  const tableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") {
+  const nextBlocks = [...getTargetBlocks(current, zone)];
+  const originalTableBlock = nextBlocks[location.blockIndex] as EditorTableNode;
+  if (!originalTableBlock || originalTableBlock.type !== "table") {
     return edit(current);
   }
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  nextBlocks[location.blockIndex] = tableBlock;
 
   const targetCell =
     tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,13 +47,13 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -199,13 +199,13 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1) {
       return current;
@@ -303,13 +303,13 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -438,13 +438,13 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -107,11 +107,13 @@ export function createTableSelectionAwareCommands(
 
       const tempResult = command(tempState);
       const resultParagraphs = getParagraphs(tempResult);
-      const targetBlocks = deps.getTargetBlocks(current, zone).map(cloneBlock);
-      const tableBlock = targetBlocks[blockIndex] as EditorTableNode;
-      if (!tableBlock) {
+      const targetBlocks = [...deps.getTargetBlocks(current, zone)];
+      const originalTableBlock = targetBlocks[blockIndex] as EditorTableNode;
+      if (!originalTableBlock) {
         return current;
       }
+      const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+      targetBlocks[blockIndex] = tableBlock;
 
       let paragraphIndex = 0;
       for (let index = 0; index < cells.length; index += 1) {

--- a/src/core/document/blockReplacement.ts
+++ b/src/core/document/blockReplacement.ts
@@ -33,21 +33,44 @@ export function replaceParagraphsInBlocks(
 
   let index = 0;
   const processBlocks = (nodes: EditorBlockNode[]): EditorBlockNode[] => {
-    return nodes.map((node) => {
+    let changed = false;
+    const result = nodes.map((node) => {
       if (node.type === "paragraph") {
-        return newParagraphs[index++] ?? node;
+        const next = newParagraphs[index++];
+        if (next && next !== node) {
+          changed = true;
+          return next;
+        }
+        return node;
       }
-      return {
-        ...node,
-        rows: node.rows.map((row) => ({
-          ...row,
-          cells: row.cells.map((cell) => ({
-            ...cell,
-            blocks: processBlocks(cell.blocks) as EditorParagraphNode[],
-          })),
-        })),
-      };
+
+      let tableChanged = false;
+      const nextRows = node.rows.map((row) => {
+        let rowChanged = false;
+        const nextCells = row.cells.map((cell) => {
+          const nextBlocks = processBlocks(cell.blocks) as EditorParagraphNode[];
+          if (nextBlocks !== cell.blocks) {
+            rowChanged = true;
+            return { ...cell, blocks: nextBlocks };
+          }
+          return cell;
+        });
+
+        if (rowChanged) {
+          tableChanged = true;
+          return { ...row, cells: nextCells };
+        }
+        return row;
+      });
+
+      if (tableChanged) {
+        changed = true;
+        return { ...node, rows: nextRows };
+      }
+      return node;
     });
+
+    return changed ? result : nodes;
   };
   return processBlocks(blocks);
 }
@@ -139,20 +162,41 @@ export function updateTableCellsInBlocks(
   selectedParagraphIds: Set<string>,
   updateCell: (cell: EditorTableCellNode) => EditorTableCellNode,
 ): EditorBlockNode[] {
-  return blocks.map((block) => {
+  let blocksChanged = false;
+  const result = blocks.map((block) => {
     if (block.type === "paragraph") return block;
 
-    return {
-      ...block,
-      rows: block.rows.map((row) => ({
-        ...row,
-        cells: row.cells.map((cell) => {
-          const isSelected = cell.blocks.some((paragraph) =>
-            selectedParagraphIds.has(paragraph.id),
-          );
-          return isSelected ? updateCell(cell) : cell;
-        }),
-      })),
-    };
+    let tableChanged = false;
+    const nextRows = block.rows.map((row) => {
+      let rowChanged = false;
+      const nextCells = row.cells.map((cell) => {
+        const isSelected = cell.blocks.some((paragraph) =>
+          selectedParagraphIds.has(paragraph.id),
+        );
+
+        if (isSelected) {
+          const nextCell = updateCell(cell);
+          if (nextCell !== cell) {
+            rowChanged = true;
+            return nextCell;
+          }
+        }
+        return cell;
+      });
+
+      if (rowChanged) {
+        tableChanged = true;
+        return { ...row, cells: nextCells };
+      }
+      return row;
+    });
+
+    if (tableChanged) {
+      blocksChanged = true;
+      return { ...block, rows: nextRows };
+    }
+    return block;
   });
+
+  return blocksChanged ? result : blocks;
 }


### PR DESCRIPTION
The editor was experiencing severe input-to-layout latency (often multi-second) during edits in a table block due to the destruction of document structural sharing.

*  `applyTableAwareParagraphEdit` and `tableOpsSelectionAwareCommands` were mapping `cloneBlock` over *every block* in the section instead of only the affected table.
* `replaceParagraphsInBlocks` and `updateTableCellsInBlocks` in `blockReplacement.ts` were deep-cloning all rows/cells even if the nested paragraphs were completely unchanged, breaking strict referential equality.

By implementing strict structural sharing (returning original reference when no nodes change and only cloning the exact table block that needs modification), layout engine recalculations are isolated only to the parts of the document that were physically altered, completely removing the input-to-layout slowdowns.

---
*PR created automatically by Jules for task [7960392693304841779](https://jules.google.com/task/7960392693304841779) started by @celsowm*