### PR TITLE
Fix severe performance lag during selection and table operations

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,10 +45,10 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[range.blockIndex]) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -104,10 +104,10 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[range.blockIndex]) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -213,10 +213,10 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -273,10 +273,10 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,10 +47,10 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -199,10 +199,10 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -303,10 +303,10 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -438,10 +438,10 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const originalBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalBlocks];
+    const tableBlock = cloneBlock(targetBlocks[location.blockIndex]) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/ui/OasisEditorApp.tsx
+++ b/src/ui/OasisEditorApp.tsx
@@ -259,7 +259,6 @@ export function OasisEditorApp(props: OasisEditorAppProps = {}) {
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
The user reported severe performance issues when editing or selecting text in complex documents (with input-to-layout latencies spiking to 4+ seconds). 

The issue was traced to unnecessary and expensive cloning operations:
1. `applySelectionToStatePreservingStructure` in `src/ui/OasisEditorApp.tsx` was executing `cloneEditorState(current).document`, completely deep cloning the entire document for every mouse drag / selection change. This destroyed structural sharing.
2. In table operations (`src/app/controllers/tableOpsRowColumnCommands.ts` and `src/app/controllers/tableOpsCellSpanCommands.ts`), blocks were globally deep-cloned via `.map(cloneBlock)` across all elements instead of selectively targeting modified ones.

Fixes applied:
- Replaced the global `cloneBlock(current).document` in `applySelectionToStatePreservingStructure` with a shallow spread `...current`.
- Changed `map(cloneBlock)` in `tableOpsRowColumnCommands.ts` and `tableOpsCellSpanCommands.ts` to shallowly copy the target blocks array and selectively `cloneBlock()` only the specific table block being modified.
- Tests successfully pass after the performance updates.

---
*PR created automatically by Jules for task [2317629720668220194](https://jules.google.com/task/2317629720668220194) started by @celsowm*