### PR TITLE
perf: resolve massive input latency and selection lag via strict structural sharing

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,10 +45,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[range.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -104,10 +105,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[range.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -213,10 +215,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -273,10 +276,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,10 +47,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -199,10 +200,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -303,10 +305,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -438,10 +441,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/ui/OasisEditorApp.tsx
+++ b/src/ui/OasisEditorApp.tsx
@@ -351,7 +351,6 @@ export function OasisEditorApp(props: OasisEditorAppProps = {}) {
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
The editor was exhibiting severe latency (up to 4.4 seconds for backspace) and slow selection sweeps due to O(N) arrays deep-cloning scaling dynamically to block sizing. This PR eliminates structural sharing breakdowns:
1. Replaces `.map(cloneBlock)` targeting all `blocks` in a zone during Table ops with shallow copies targeting *only* the specific table.
2. Removes deep document cloning via `cloneEditorState(current).document` in `applySelectionToStatePreservingStructure` to prevent entire-page clone allocation thrashing per keystroke/drag.

---
*PR created automatically by Jules for task [1817861722672153583](https://jules.google.com/task/1817861722672153583) started by @celsowm*