### PR TITLE
perf: improve performance of table operations by replacing map(cloneBlock) with shallow copies

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,13 +45,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTable = currentBlocks[range.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -104,13 +105,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTable = currentBlocks[range.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
@@ -213,13 +215,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
@@ -273,13 +276,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -64,15 +64,13 @@ export const applyTableAwareParagraphEdit = (
 
   const zone = location.zone;
   const currentBlocks = getTargetBlocks(current, zone);
-  const clonedTable = cloneBlock(
-    currentBlocks[location.blockIndex],
-  ) as EditorTableNode;
-  if (!clonedTable || clonedTable.type !== "table") {
+  const originalTable = currentBlocks[location.blockIndex];
+  if (!originalTable || originalTable.type !== "table") {
     return edit(current);
   }
-  const nextBlocks = currentBlocks.map((block, i) =>
-    i === location.blockIndex ? clonedTable : block,
-  );
+  const clonedTable = cloneBlock(originalTable) as EditorTableNode;
+  const nextBlocks = [...currentBlocks];
+  nextBlocks[location.blockIndex] = clonedTable;
   const tableBlock = clonedTable;
 
   const targetCell =

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,13 +47,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -199,13 +200,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1) {
       return current;
@@ -303,13 +305,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -438,13 +441,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTable = currentBlocks[location.blockIndex];
+    if (!originalTable || originalTable.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTable) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -108,15 +108,13 @@ export function createTableSelectionAwareCommands(
       const tempResult = command(tempState);
       const resultParagraphs = getParagraphs(tempResult);
       const currentBlocks = deps.getTargetBlocks(current, zone);
-      const clonedTable = cloneBlock(
-        currentBlocks[blockIndex],
-      ) as EditorTableNode;
-      if (!clonedTable) {
+      const originalTable = currentBlocks[blockIndex];
+      if (!originalTable || originalTable.type !== "table") {
         return current;
       }
-      const targetBlocks = currentBlocks.map((block, i) =>
-        i === blockIndex ? clonedTable : block,
-      );
+      const clonedTable = cloneBlock(originalTable) as EditorTableNode;
+      const targetBlocks = [...currentBlocks];
+      targetBlocks[blockIndex] = clonedTable;
       const tableBlock = clonedTable;
 
       let paragraphIndex = 0;


### PR DESCRIPTION
Fixed severe performance bottleneck where table editing operations resulted in multi-second input delays due to `O(N)` deep-clones of all document blocks via `array.map(cloneBlock)`. Replaced with shallow cloning (`[...blocks]`) and targeted `cloneBlock` for only the modified block to preserve structural sharing.

---
*PR created automatically by Jules for task [14721757040676611646](https://jules.google.com/task/14721757040676611646) started by @celsowm*