### PR TITLE
Fix drag selection performance issues

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,14 +45,16 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = sourceBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
-
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
       return current;
@@ -104,14 +106,16 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = sourceBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
-
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
     > = [];
@@ -213,14 +217,16 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
-
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
     if (!cell || span <= 1 || cell.vMerge !== "restart") {
@@ -273,14 +279,16 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
-
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];
     const span = Math.max(1, cell?.colSpan ?? 1);

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,13 +47,16 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -199,13 +202,16 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1) {
       return current;
@@ -303,13 +309,16 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -438,13 +447,16 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const sourceBlocks = deps.getTargetBlocks(current, location.zone);
+    const originalTableBlock = sourceBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...sourceBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -108,16 +108,13 @@ export function createTableSelectionAwareCommands(
       const tempResult = command(tempState);
       const resultParagraphs = getParagraphs(tempResult);
       const currentBlocks = deps.getTargetBlocks(current, zone);
-      const clonedTable = cloneBlock(
-        currentBlocks[blockIndex],
-      ) as EditorTableNode;
-      if (!clonedTable) {
+      const originalTableBlock = currentBlocks[blockIndex] as EditorTableNode;
+      if (!originalTableBlock || originalTableBlock.type !== "table") {
         return current;
       }
-      const targetBlocks = currentBlocks.map((block, i) =>
-        i === blockIndex ? clonedTable : block,
-      );
-      const tableBlock = clonedTable;
+      const targetBlocks = [...currentBlocks];
+      const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+      targetBlocks[blockIndex] = tableBlock;
 
       let paragraphIndex = 0;
       for (let index = 0; index < cells.length; index += 1) {

--- a/src/ui/OasisEditorApp.tsx
+++ b/src/ui/OasisEditorApp.tsx
@@ -368,7 +368,6 @@ export function OasisEditorApp(props: OasisEditorAppProps = {}) {
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Fixes a massive performance regression where the editor lagged heavily during simple operations such as typing, drag-selecting, and modifying tables. The issue stemmed from destroying structural sharing during selection and table operations by doing full deep clones instead of targeted shallow clones.

---
*PR created automatically by Jules for task [6699912390058834938](https://jules.google.com/task/6699912390058834938) started by @celsowm*