### PR TITLE
perf: resolve selection and editing lag by retaining structural sharing

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -45,10 +45,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[range.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -104,10 +105,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[range.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -213,10 +215,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -273,10 +276,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -47,10 +47,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -199,10 +200,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -303,10 +305,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }
@@ -438,10 +441,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const tableBlock = cloneBlock(
+      targetBlocks[location.blockIndex],
+    ) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
     }

--- a/src/app/controllers/useEditorHistoryActions.ts
+++ b/src/app/controllers/useEditorHistoryActions.ts
@@ -182,10 +182,7 @@ export function createEditorHistoryActions(deps: UseEditorHistoryActionsProps) {
     const snapshot = deps.stateSnapshot();
     deps.applyHistoryState({
       ...snapshot,
-      document: {
-        ...snapshot.document,
-        sections: snapshot.document.sections?.map(cloneSection),
-      },
+      document: snapshot.document,
       selection: {
         anchor: { ...nextSelection.anchor },
         focus: { ...nextSelection.focus },

--- a/src/ui/OasisEditorApp.tsx
+++ b/src/ui/OasisEditorApp.tsx
@@ -305,7 +305,7 @@ export function OasisEditorApp(props: OasisEditorAppProps = {}) {
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
The application suffered from huge lagging performance during selection, text entry, and dragging across large documents or tables. Profiling logs showed `input:text` resolving somewhat quickly but input-to-layout times dramatically stalling. Analysis identified that several `selection` or isolated command handlers were using `.map(cloneBlock)`, `cloneSection`, or `cloneEditorState` deep cloners on massive arrays instead of preserving structural sharing. This meant even small range selections would cause the virtual DOM/layout cache comparisons to miss, forcing layout re-renders across unaffected paragraphs. I have optimized the array mappings into shallow spread-based mutations, restoring 1:1 structural sharing for unchanged elements.

---
*PR created automatically by Jules for task [4999087524571588029](https://jules.google.com/task/4999087524571588029) started by @celsowm*