### PR TITLE
perf: Fix severe performance issue during table edits

### DIFF
--- a/fix_table_ops.cjs
+++ b/fix_table_ops.cjs
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+function replaceMapCloneBlock(file) {
+  let content = fs.readFileSync(file, 'utf8');
+  content = content.replace(
+    /const targetBlocks = deps\s*\n\s*\.getTargetBlocks\(current, (location|range)\.zone\)\s*\n\s*\.map\(cloneBlock\);/g,
+    `const targetBlocks = [...deps.getTargetBlocks(current, $1.zone)];\n    const originalTableBlock = targetBlocks[$1.blockIndex];\n    if (originalTableBlock) {\n      targetBlocks[$1.blockIndex] = cloneBlock(originalTableBlock);\n    }`
+  );
+  fs.writeFileSync(file, content);
+}
+
+replaceMapCloneBlock('src/app/controllers/tableOpsRowColumnCommands.ts');
+replaceMapCloneBlock('src/app/controllers/tableOpsCellSpanCommands.ts');

--- a/fix_table_ops.js
+++ b/fix_table_ops.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+function replaceMapCloneBlock(file) {
+  let content = fs.readFileSync(file, 'utf8');
+  content = content.replace(
+    /const targetBlocks = deps\s*\n\s*\.getTargetBlocks\(current, (location|range)\.zone\)\s*\n\s*\.map\(cloneBlock\);/g,
+    `const targetBlocks = [...deps.getTargetBlocks(current, $1.zone)];\n    const originalTableBlock = targetBlocks[$1.blockIndex];\n    if (originalTableBlock) {\n      targetBlocks[$1.blockIndex] = cloneBlock(originalTableBlock);\n    }`
+  );
+  fs.writeFileSync(file, content);
+}
+
+replaceMapCloneBlock('src/app/controllers/tableOpsRowColumnCommands.ts');
+replaceMapCloneBlock('src/app/controllers/tableOpsCellSpanCommands.ts');

--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -60,9 +60,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[range.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -144,9 +146,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[range.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -278,9 +282,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -372,9 +378,11 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -48,9 +48,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -218,9 +220,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -332,9 +336,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -506,9 +512,11 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (originalTableBlock) {
+      targetBlocks[location.blockIndex] = cloneBlock(originalTableBlock);
+    }
     const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;


### PR DESCRIPTION
Optimize table text edit performance by avoiding deep clones of the entire table on every keystroke.

---
*PR created automatically by Jules for task [9250902687943350314](https://jules.google.com/task/9250902687943350314) started by @celsowm*