### PR TITLE
perf: optimize O(N) full document clones into targeted shallow object cloning

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -60,13 +60,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +145,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
@@ -278,13 +280,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
@@ -372,13 +375,14 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -63,16 +63,14 @@ export const applyTableAwareParagraphEdit = (
   }
 
   const zone = location.zone;
-  const currentBlocks = getTargetBlocks(current, zone);
-  const clonedTable = cloneBlock(
-    currentBlocks[location.blockIndex],
-  ) as EditorTableNode;
-  if (!clonedTable || clonedTable.type !== "table") {
+  const originalBlocks = getTargetBlocks(current, zone);
+  const nextBlocks = [...originalBlocks];
+  const originalTable = originalBlocks[location.blockIndex];
+  if (!originalTable || originalTable.type !== "table") {
     return edit(current);
   }
-  const nextBlocks = currentBlocks.map((block, i) =>
-    i === location.blockIndex ? clonedTable : block,
-  );
+  const clonedTable = cloneBlock(originalTable) as EditorTableNode;
+  nextBlocks[location.blockIndex] = clonedTable;
   const tableBlock = clonedTable;
 
   const targetCell =

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -48,13 +48,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -218,13 +219,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1 && !current.trackChangesEnabled) {
       return current;
@@ -332,13 +334,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -506,13 +509,14 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalTargetBlocks = deps.getTargetBlocks(current, location.zone);
+    const targetBlocks = [...originalTargetBlocks];
+    const originalTableBlock = targetBlocks[location.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/app/controllers/useEditorHistoryActions.ts
+++ b/src/app/controllers/useEditorHistoryActions.ts
@@ -15,7 +15,6 @@ import {
 } from "@/core/model.js";
 import { createEditorParagraph } from "@/core/editorState.js";
 import { moveSelectedImageToPosition } from "@/core/commands/image.js";
-import { cloneSection } from "@/core/cloneState.js";
 import type { createEditorImageOperations } from "./useEditorImageOperations.js";
 
 export interface UseEditorHistoryActionsProps {
@@ -183,10 +182,7 @@ export function createEditorHistoryActions(deps: UseEditorHistoryActionsProps) {
     const snapshot = deps.stateSnapshot();
     deps.applyHistoryState({
       ...snapshot,
-      document: {
-        ...snapshot.document,
-        sections: snapshot.document.sections?.map(cloneSection),
-      },
+      document: snapshot.document,
       selection: {
         anchor: { ...nextSelection.anchor },
         focus: { ...nextSelection.focus },


### PR DESCRIPTION
Fixes severe layout lagging on keystrokes (`Backspace`, arrow keys) inside tables and document body. By utilizing standard structural sharing, modifying a single document cell or altering the active selection no longer triggers a complete recursive `cloneBlock` over every single element in the document chunk array.

---
*PR created automatically by Jules for task [8271280895918938063](https://jules.google.com/task/8271280895918938063) started by @celsowm*