### PR TITLE
perf: optimize selection updates and table mutations to preserve structural sharing

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -60,13 +60,15 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +146,15 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>
@@ -278,13 +282,15 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const cell = tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
     const span = Math.max(1, cell?.rowSpan ?? 1);
@@ -372,13 +378,15 @@ export function createTableCellSpanOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[location.rowIndex];
     const cell = row?.cells[location.cellIndex];

--- a/src/app/controllers/tableOpsRowColumnCommands.ts
+++ b/src/app/controllers/tableOpsRowColumnCommands.ts
@@ -48,13 +48,15 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const sourceRow = tableBlock.rows[location.rowIndex];
     if (!sourceRow) {
@@ -218,13 +220,15 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (tableBlock.rows.length <= 1 && !current.trackChangesEnabled) {
       return current;
@@ -332,13 +336,15 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     const hasHorizontalSpansInTable = tableBlock.rows.some((row) =>
       row.cells.some((cell) => Math.max(1, cell.colSpan ?? 1) > 1),
@@ -506,13 +512,15 @@ export function createTableRowColumnOperations(
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, location.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, location.zone)];
+    const originalTableBlock = targetBlocks[
+      location.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[location.blockIndex] = tableBlock;
 
     if (getTableVisualWidth(tableBlock) <= 1) {
       return current;

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -114,7 +114,6 @@ export function createEditorInteractionRuntime(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
This PR addresses severe performance issues (latency spikes during input and selection drags) caused by excessive deep cloning.

1. `applySelectionToStatePreservingStructure` was deep-cloning the entire document merely to update the selection. We now reuse `current.document`.
2. Table mutations (insert/delete rows/columns, merge/split cells) were iterating over all blocks in a section and calling `cloneBlock` on all of them via `.map(cloneBlock)`. We now shallow-copy the blocks array, clone only the target table, and insert it back, ensuring structural sharing is maintained for all other document blocks.

---
*PR created automatically by Jules for task [15173983198899971828](https://jules.google.com/task/15173983198899971828) started by @celsowm*