### PR TITLE
perf: optimize document cloning in table ops and selections

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,13 +66,16 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = currentBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +147,16 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = currentBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const targetBlocks = [...currentBlocks];
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -65,17 +65,15 @@ export const applyTableAwareParagraphEdit = (
 
   const zone = location.zone;
   const currentBlocks = getTargetBlocks(current, zone);
-  const clonedTable = cloneBlock(
-    currentBlocks[location.blockIndex],
-  ) as EditorTableNode;
-  if (!clonedTable || clonedTable.type !== "table") {
+  const originalTableBlock = currentBlocks[
+    location.blockIndex
+  ] as EditorTableNode;
+  if (!originalTableBlock || originalTableBlock.type !== "table") {
     return edit(current);
   }
-  const nextBlocks = currentBlocks.map(
-    (block, i): EditorBlockNode =>
-      i === location.blockIndex ? clonedTable : block,
-  );
-  const tableBlock = clonedTable;
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  const nextBlocks = [...currentBlocks];
+  nextBlocks[location.blockIndex] = tableBlock;
 
   const targetCell =
     tableBlock.rows[location.rowIndex]?.cells[location.cellIndex];
@@ -134,9 +132,14 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") return null;
+  const currentBlocks = getTargetBlocks(current, location.zone);
+  const originalTableBlock = currentBlocks[
+    location.blockIndex
+  ] as EditorTableNode;
+  if (!originalTableBlock || originalTableBlock.type !== "table") return null;
+  const targetBlocks = [...currentBlocks];
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  targetBlocks[location.blockIndex] = tableBlock;
   return { tableBlock, location, targetBlocks };
 }
 

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -122,9 +122,8 @@ function createTableSelectionAwareCommandsImpl(
       if (!clonedTable) {
         return current;
       }
-      const targetBlocks = currentBlocks.map(
-        (block, i): EditorBlockNode => (i === blockIndex ? clonedTable : block),
-      );
+      const targetBlocks = [...currentBlocks];
+      targetBlocks[blockIndex] = clonedTable;
       const tableBlock = clonedTable;
 
       let paragraphIndex = 0;

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -1,6 +1,6 @@
 import { getSelectedImageRun } from "@/core/commands/image.js";
 import { getSelectedTextBoxRun } from "@/core/commands/textBox.js";
-import { cloneEditorState } from "@/core/cloneState.js";
+
 import type { EditorPosition, EditorState } from "@/core/model.js";
 import type { EditorLogger } from "@/utils/logger.js";
 import { createEditorTableOperations } from "@/app/controllers/useEditorTableOperations.js";
@@ -125,7 +125,7 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
This PR addresses significant performance bottlenecks where the application would lag severely during text input, selection dragging, and table operations. The root cause was identified as heavy usage of `.map(cloneBlock)` across all table blocks and `cloneEditorState` deep-cloning the entire document merely upon selection updates. By utilizing shallow copies and selectively deep-cloning only the mutated nodes, structural sharing is restored and performance dramatically improved.

---
*PR created automatically by Jules for task [16382180311768818522](https://jules.google.com/task/16382180311768818522) started by @celsowm*