### PR TITLE
Fix severe performance freeze on selection updates

### DIFF
--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,6 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Removed an unnecessary deep clone of the document during selection updates in `createEditorInteractionRuntime.ts`. This was causing massive input-to-layout delays (e.g., thousands of milliseconds on large documents) when navigating or selecting text. By reusing the document reference, we maintain structural sharing and restore responsive text editing.

---
*PR created automatically by Jules for task [2652070505700732253](https://jules.google.com/task/2652070505700732253) started by @celsowm*