### PR TITLE
Fix performance bottleneck on text selection/input

### DIFF
--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,6 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Removed the deep clone of the document from `applySelectionToStatePreservingStructure` in `src/ui/app/createEditorInteractionRuntime.ts`. This was causing a massive layout delay on every key press and selection drag, because the layout engine couldn't use reference equality to skip unchanged document blocks.

---
*PR created automatically by Jules for task [8368731896412508240](https://jules.google.com/task/8368731896412508240) started by @celsowm*