### PR TITLE
Fix native UI guardrail violations

### DIFF
--- a/src/ui/components/Toolbar/TableBordersMenu.tsx
+++ b/src/ui/components/Toolbar/TableBordersMenu.tsx
@@ -2,8 +2,11 @@ import { For, createSignal, type JSX } from "solid-js";
 import type { TableBorderPreset } from "@/core/commands/table.js";
 import type { ToolbarActionApi } from "./schema/items.js";
 import { Popover } from "./primitives/Popover.js";
+import { Button } from "./primitives/Button.js";
 import { DropdownChevron } from "./primitives/DropdownChevron.js";
 import { ToolIcon } from "@/ui/utils/customIcons.js";
+import { SurfaceButton } from "@/ui/public/SurfaceButton.js";
+import { Text } from "@/ui/public/Text.js";
 
 type MenuItem = { preset: TableBorderPreset; label: string };
 const GROUPS: MenuItem[][] = [
@@ -89,20 +92,19 @@ export function TableBordersMenu(props: {
       panelRole="menu"
       panelClass="oasis-editor-table-borders-menu"
       trigger={(popover): JSX.Element => (
-        <button
+        <Button
           ref={popover.ref}
-          type="button"
-          class="oasis-editor-tool-button oasis-editor-table-borders-trigger"
-          classList={{ "oasis-editor-tool-button-active": popover.open }}
+          class="oasis-editor-table-borders-trigger"
+          active={popover.open}
           aria-haspopup="menu"
           aria-expanded={popover.open}
-          title="Bordas"
+          tooltip="Bordas"
           onClick={(): void => popover.toggle()}
         >
           <ToolIcon name="tableBorders" />
-          <span>Bordas</span>
+          <Text>Bordas</Text>
           <DropdownChevron />
-        </button>
+        </Button>
       )}
     >
       <For each={GROUPS}>
@@ -110,15 +112,15 @@ export function TableBordersMenu(props: {
           <div class="oasis-editor-table-borders-section">
             <For each={group}>
               {(item): JSX.Element => (
-                <button
-                  type="button"
+                <SurfaceButton
                   class="oasis-editor-table-borders-action"
                   role="menuitem"
+                  label={item.label}
                   onClick={(): void => apply(item.preset)}
                 >
                   <Preview preset={item.preset} />
-                  <span>{item.label}</span>
-                </button>
+                  <Text>{item.label}</Text>
+                </SurfaceButton>
               )}
             </For>
             {index() < GROUPS.length - 1 && (
@@ -128,50 +130,50 @@ export function TableBordersMenu(props: {
         )}
       </For>
       <div class="oasis-editor-table-borders-divider" />
-      <button
-        type="button"
+      <SurfaceButton
         class="oasis-editor-table-borders-action"
         role="menuitem"
+        label="Linha Horizontal"
         onClick={(): void => apply("bottom")}
       >
-        <span class="oasis-editor-table-borders-text-icon">A</span>
-        <span>Linha Horizontal</span>
-      </button>
-      <button
-        type="button"
+        <Text class="oasis-editor-table-borders-text-icon">A</Text>
+        <Text>Linha Horizontal</Text>
+      </SurfaceButton>
+      <SurfaceButton
         class="oasis-editor-table-borders-action"
         role="menuitem"
+        label="Desenhar Tabela"
         onClick={(): void => {
           props.api.commands.execute("toggleTableDrawBorders");
           setOpen(false);
         }}
       >
         <ToolIcon name="tableBorders" />
-        <span>Desenhar Tabela</span>
-      </button>
-      <button
-        type="button"
+        <Text>Desenhar Tabela</Text>
+      </SurfaceButton>
+      <SurfaceButton
         class="oasis-editor-table-borders-action"
         role="menuitem"
+        label="Exibir Linhas de Grade"
         onClick={(): void => {
           props.api.commands.execute("toggleTableGridlines");
           setOpen(false);
         }}
       >
         <ToolIcon name="tableBorders" />
-        <span>Exibir Linhas de Grade</span>
-      </button>
-      <button
-        type="button"
+        <Text>Exibir Linhas de Grade</Text>
+      </SurfaceButton>
+      <SurfaceButton
         class="oasis-editor-table-borders-action"
         role="menuitem"
+        label="Bordas e Sombreamento…"
         onClick={(): void => {
           props.api.commands.execute("tableCellBorders");
         }}
       >
         <ToolIcon name="tableBorders" />
-        <span>Bordas e Sombreamento…</span>
-      </button>
+        <Text>Bordas e Sombreamento…</Text>
+      </SurfaceButton>
     </Popover>
   );
 }

--- a/src/ui/components/Toolbar/TableStyleGallery.tsx
+++ b/src/ui/components/Toolbar/TableStyleGallery.tsx
@@ -9,6 +9,8 @@ import {
 import type { ToolbarActionApi, ToolbarDocumentStyle } from "./schema/items.js";
 import { Popover } from "./primitives/Popover.js";
 import { DropdownChevron } from "./primitives/DropdownChevron.js";
+import { SurfaceButton } from "@/ui/public/SurfaceButton.js";
+import { Text } from "@/ui/public/Text.js";
 
 export interface TableStyleGalleryProps {
   api: ToolbarActionApi;
@@ -91,19 +93,20 @@ export function TableStyleGallery(props: TableStyleGalleryProps): JSX.Element {
         const preview = (): NonNullable<ToolbarDocumentStyle["tablePreview"]> =>
           style.tablePreview ?? {};
         return (
-          <button
-            type="button"
+          <SurfaceButton
             class="oasis-editor-table-style-card"
+            active={isActive(style)}
             classList={{
               "oasis-editor-table-style-card-active": isActive(style),
             }}
             role="option"
             aria-selected={isActive(style)}
             title={style.name}
+            label={style.name}
             data-style-id={style.id}
             onClick={(): void => apply(style)}
           >
-            <span
+            <Text
               class="oasis-editor-table-style-preview"
               style={{
                 "--table-fill": preview().wholeFill ?? "#ffffff",
@@ -124,11 +127,11 @@ export function TableStyleGallery(props: TableStyleGalleryProps): JSX.Element {
               <i />
               <i />
               <i />
-            </span>
-            <span class="oasis-editor-table-style-card-label">
+            </Text>
+            <Text class="oasis-editor-table-style-card-label">
               {style.name}
-            </span>
-          </button>
+            </Text>
+          </SurfaceButton>
         );
       }}
     </For>
@@ -138,9 +141,9 @@ export function TableStyleGallery(props: TableStyleGalleryProps): JSX.Element {
     <Show
       when={styles().length > 0}
       fallback={
-        <span class="oasis-editor-table-style-gallery-empty">
+        <Text class="oasis-editor-table-style-gallery-empty">
           {props.api.t("table.tableStyle")}
-        </span>
+        </Text>
       }
     >
       <Popover
@@ -155,17 +158,16 @@ export function TableStyleGallery(props: TableStyleGalleryProps): JSX.Element {
             <div class="oasis-editor-table-style-strip" role="listbox">
               {cards()}
             </div>
-            <button
-              type="button"
+            <SurfaceButton
               class="oasis-editor-table-style-expand"
-              aria-label={props.api.t("table.tableStyle")}
+              label={props.api.t("table.tableStyle")}
               aria-haspopup="listbox"
               aria-expanded={popover.open}
               data-testid={`${testId()}-expand`}
               onClick={(): void => popover.toggle()}
             >
               <DropdownChevron />
-            </button>
+            </SurfaceButton>
           </div>
         )}
       >

--- a/src/ui/components/Toolbar/TableStyleOptions.tsx
+++ b/src/ui/components/Toolbar/TableStyleOptions.tsx
@@ -1,6 +1,7 @@
 import { For, type JSX } from "solid-js";
 import type { TranslationKey } from "@/i18n/index.js";
 import type { ToolbarActionApi } from "./schema/items.js";
+import { Checkbox } from "@/ui/public/Checkbox.js";
 
 const OPTIONS: Array<{ command: string; label: TranslationKey }> = [
   { command: "tableToggleHeaderRow", label: "table.headerRow" },
@@ -21,17 +22,15 @@ export function TableStyleOptions(props: {
           const state = (): boolean =>
             props.api.commands.state(option.command).isActive;
           return (
-            <label class="oasis-editor-table-style-option">
-              <input
-                type="checkbox"
-                checked={state()}
-                disabled={!props.api.commands.state(option.command).isEnabled}
-                onChange={(): void => {
-                  props.api.commands.execute(option.command);
-                }}
-              />
-              <span>{props.api.t(option.label)}</span>
-            </label>
+            <Checkbox
+              class="oasis-editor-table-style-option"
+              label={props.api.t(option.label)}
+              checked={state()}
+              disabled={!props.api.commands.state(option.command).isEnabled}
+              onChange={(): void => {
+                props.api.commands.execute(option.command);
+              }}
+            />
           );
         }}
       </For>

--- a/src/ui/components/Toolbar/toolbar.css
+++ b/src/ui/components/Toolbar/toolbar.css
@@ -1895,6 +1895,15 @@
   cursor: pointer;
 }
 
+.oasis-editor-table-style-option .oasis-editor-ui-checkbox-copy {
+  display: contents;
+}
+
+.oasis-editor-table-style-option .oasis-editor-ui-field-label {
+  font: inherit;
+  color: inherit;
+}
+
 .oasis-editor-table-style-option input {
   width: 13px;
   height: 13px;
@@ -1936,6 +1945,8 @@
   color: var(--oasis-ribbon-text, var(--oasis-text));
   cursor: pointer;
   box-sizing: border-box;
+  border-radius: 0;
+  font-weight: 400;
 }
 
 .oasis-editor-table-style-preview {
@@ -1991,6 +2002,8 @@
   background: var(--oasis-ribbon-hover, #ededed);
   color: var(--oasis-ribbon-text, #333);
   cursor: pointer;
+  min-height: 0;
+  border-radius: 0;
 }
 
 .oasis-editor-table-style-expand:hover,
@@ -2046,6 +2059,9 @@
   font-size: 12px;
   text-align: left;
   cursor: pointer;
+  justify-content: flex-start;
+  border-radius: 0;
+  font-weight: 400;
 }
 
 .oasis-editor-table-borders-action:hover,


### PR DESCRIPTION
## What changed

- replace raw table-toolbar buttons and text wrappers with shared Oasis UI primitives
- replace native table-style checkboxes with the public Checkbox primitive
- preserve the existing ribbon layout with narrowly scoped CSS adjustments

## Why

The latest main-branch workflows failed because the native UI guardrail detected raw `button`, `span`, `label`, and `input` elements in the new table toolbar components.

## Impact

Table border, table style gallery, and table style option behavior remains unchanged while the components now comply with the shared UI surface and future guardrail checks.

## Validation

- `npm test` (830 passed, 1 skipped)
- `npx tsc --noEmit`
- focused ESLint
- `npm run check:native-ui`
- `npm run build:lib`
- `git diff --check`
