### PR TITLE
perf: fix severe input and layout latency by preserving structural sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vue": "^3.5.39"
       },
       "peerDependencies": {
-        "react": ">=18",
+        "react": ">=17",
         "vue": ">=3"
       },
       "peerDependenciesMeta": {

--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,13 +66,14 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +145,14 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -134,9 +134,12 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") return null;
+  const originalBlocks = getTargetBlocks(current, location.zone);
+  const targetBlocks = [...originalBlocks];
+  const originalTableBlock = targetBlocks[location.blockIndex];
+  if (!originalTableBlock || originalTableBlock.type !== "table") return null;
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  targetBlocks[location.blockIndex] = tableBlock;
   return { tableBlock, location, targetBlocks };
 }
 

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -116,16 +116,13 @@ function createTableSelectionAwareCommandsImpl(
       const tempResult = command(tempState);
       const resultParagraphs = getParagraphs(tempResult);
       const currentBlocks = deps.getTargetBlocks(current, zone);
-      const clonedTable = cloneBlock(
-        currentBlocks[blockIndex],
-      ) as EditorTableNode;
-      if (!clonedTable) {
+      const targetBlocks = [...currentBlocks];
+      const originalTableBlock = targetBlocks[blockIndex];
+      if (!originalTableBlock) {
         return current;
       }
-      const targetBlocks = currentBlocks.map(
-        (block, i): EditorBlockNode => (i === blockIndex ? clonedTable : block),
-      );
-      const tableBlock = clonedTable;
+      const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+      targetBlocks[blockIndex] = tableBlock;
 
       let paragraphIndex = 0;
       for (let index = 0; index < cells.length; index += 1) {

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,7 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Replaces array-level map operations with `cloneBlock` with an immutable shallow array copy that only deep-clones the specific table block being mutated. Also avoids cloning the entire editor state during selection updates, resolving a severe performance issue where single keystrokes could trigger full document layout cycles.

---
*PR created automatically by Jules for task [8621843425489610303](https://jules.google.com/task/8621843425489610303) started by @celsowm*