### PR TITLE
perf: fix severe performance regression by using structural sharing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vue": "^3.5.39"
       },
       "peerDependencies": {
-        "react": ">=18",
+        "react": ">=17",
         "vue": ">=3"
       },
       "peerDependenciesMeta": {

--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,13 +66,15 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +146,15 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const originalTableBlock = targetBlocks[
+      range.blockIndex
+    ] as EditorTableNode;
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -134,9 +134,13 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") return null;
+  const targetBlocks = [...getTargetBlocks(current, location.zone)];
+  const originalTableBlock = targetBlocks[
+    location.blockIndex
+  ] as EditorTableNode;
+  if (!originalTableBlock || originalTableBlock.type !== "table") return null;
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  targetBlocks[location.blockIndex] = tableBlock;
   return { tableBlock, location, targetBlocks };
 }
 

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,6 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Removed expensive document and section level deep clones that were triggered repeatedly on keydown and drag events. Replaced these with targeted shallow clones where table operations mutate layout, establishing proper structural sharing across the state immutable paths.

---
*PR created automatically by Jules for task [4067654709465808393](https://jules.google.com/task/4067654709465808393) started by @celsowm*