### PR TITLE
fix(perf): Avoid O(N) array cloning during table mutations

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,13 +66,14 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +145,14 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const originalBlocks = deps.getTargetBlocks(current, range.zone);
+    const targetBlocks = [...originalBlocks];
+    const originalTableBlock = targetBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -134,9 +134,13 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") return null;
+
+  const originalBlocks = getTargetBlocks(current, location.zone);
+  const targetBlocks = [...originalBlocks];
+  const originalTableBlock = targetBlocks[location.blockIndex];
+  if (!originalTableBlock || originalTableBlock.type !== "table") return null;
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  targetBlocks[location.blockIndex] = tableBlock;
   return { tableBlock, location, targetBlocks };
 }
 


### PR DESCRIPTION
Optimized table mutations to improve performance significantly.

---
*PR created automatically by Jules for task [8315485380726413232](https://jules.google.com/task/8315485380726413232) started by @celsowm*