### PR TITLE
Fix severe input lag by restoring structural sharing in editor runtime

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,9 +66,9 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const clonedTable = cloneBlock(targetBlocks[range.blockIndex]);
+    targetBlocks[range.blockIndex] = clonedTable;
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;
@@ -144,9 +144,9 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
+    const targetBlocks = [...deps.getTargetBlocks(current, range.zone)];
+    const clonedTable = cloneBlock(targetBlocks[range.blockIndex]);
+    targetBlocks[range.blockIndex] = clonedTable;
     const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
     if (!tableBlock || tableBlock.type !== "table") {
       return current;

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -71,10 +71,9 @@ export const applyTableAwareParagraphEdit = (
   if (!clonedTable || clonedTable.type !== "table") {
     return edit(current);
   }
-  const nextBlocks = currentBlocks.map(
-    (block, i): EditorBlockNode =>
-      i === location.blockIndex ? clonedTable : block,
-  );
+
+  const nextBlocks = [...currentBlocks];
+  nextBlocks[location.blockIndex] = clonedTable;
   const tableBlock = clonedTable;
 
   const targetCell =
@@ -134,8 +133,11 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
+  const targetBlocks = [...getTargetBlocks(current, location.zone)];
+  const tableBlock = cloneBlock(
+    targetBlocks[location.blockIndex],
+  ) as EditorTableNode;
+  targetBlocks[location.blockIndex] = tableBlock;
   if (!tableBlock || tableBlock.type !== "table") return null;
   return { tableBlock, location, targetBlocks };
 }

--- a/src/app/controllers/tableOpsSelectionAwareCommands.ts
+++ b/src/app/controllers/tableOpsSelectionAwareCommands.ts
@@ -122,9 +122,11 @@ function createTableSelectionAwareCommandsImpl(
       if (!clonedTable) {
         return current;
       }
-      const targetBlocks = currentBlocks.map(
-        (block, i): EditorBlockNode => (i === blockIndex ? clonedTable : block),
-      );
+
+      // Use targeted shallow clone pattern to maintain structural sharing
+      const targetBlocks = [...currentBlocks];
+      targetBlocks[blockIndex] = clonedTable;
+
       const tableBlock = clonedTable;
 
       let paragraphIndex = 0;

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -1,6 +1,5 @@
 import { getSelectedImageRun } from "@/core/commands/image.js";
 import { getSelectedTextBoxRun } from "@/core/commands/textBox.js";
-import { cloneEditorState } from "@/core/cloneState.js";
 import type { EditorPosition, EditorState } from "@/core/model.js";
 import type { EditorLogger } from "@/utils/logger.js";
 import { createEditorTableOperations } from "@/app/controllers/useEditorTableOperations.js";
@@ -125,7 +124,7 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,

--- a/src/ui/app/useEditorAppState.ts
+++ b/src/ui/app/useEditorAppState.ts
@@ -4,7 +4,6 @@ import {
   createEditorStateFromDocument,
   createInitialEditorState,
 } from "@/core/editorState.js";
-import { cloneEditorState } from "@/core/cloneState.js";
 
 export function createEditorAppState(options: {
   initialDocument?: EditorDocument;
@@ -16,7 +15,7 @@ export function createEditorAppState(options: {
   getStateSnapshot: () => EditorState;
 } {
   const initialEditorState = options.initialState
-    ? cloneEditorState(options.initialState)
+    ? options.initialState
     : options.initialDocument
       ? createEditorStateFromDocument(options.initialDocument)
       : createInitialEditorState();


### PR DESCRIPTION
The editor experienced severe input-to-layout delays (e.g. typing or backspacing took ~4-5 seconds) particularly during text drag, selection updates, and table interactions.

The root cause was massive loss of structural sharing across multiple modules:
- The interaction runtime (`createEditorInteractionRuntime`) was needlessly calling `cloneEditorState` on every selection update within table operations.
- Table operations were using `array.map(cloneBlock)` over entire arrays of document blocks, deep cloning every block instead of just the block being mutated.

This PR fixes these issues by updating:
- `createEditorInteractionRuntime`: Passed `current.document` reference instead of a deep clone.
- `tableOpsMutationCommands`, `tableOpsSelectionAwareCommands`, `tableOpsCellSpanCommands`: Replaced `.map(cloneBlock)` with shallow copies of the block arrays (`[...currentBlocks]`) and deep cloning only the targeted table block.
- Removed unused/costly `cloneEditorState` injections in UI hooks.

---
*PR created automatically by Jules for task [17800796684144724332](https://jules.google.com/task/17800796684144724332) started by @celsowm*