### PR TITLE
Optimize document cloning to reduce typing lag

### DIFF
--- a/src/app/controllers/tableOpsCellSpanCommands.ts
+++ b/src/app/controllers/tableOpsCellSpanCommands.ts
@@ -66,13 +66,15 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = currentBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    const targetBlocks = [...currentBlocks];
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const row = tableBlock.rows[range.rowIndex];
     if (!row) {
@@ -144,13 +146,15 @@ function createTableCellSpanOperationsImpl(deps: TableCellSpanOperationsDeps) {
       return current;
     }
 
-    const targetBlocks = deps
-      .getTargetBlocks(current, range.zone)
-      .map(cloneBlock);
-    const tableBlock = targetBlocks[range.blockIndex] as EditorTableNode;
-    if (!tableBlock || tableBlock.type !== "table") {
+    const currentBlocks = deps.getTargetBlocks(current, range.zone);
+    const originalTableBlock = currentBlocks[range.blockIndex];
+    if (!originalTableBlock || originalTableBlock.type !== "table") {
       return current;
     }
+
+    const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+    const targetBlocks = [...currentBlocks];
+    targetBlocks[range.blockIndex] = tableBlock;
 
     const selectedCells: Array<
       NonNullable<(typeof tableBlock.rows)[number]["cells"][number]>

--- a/src/app/controllers/tableOpsMutationCommands.ts
+++ b/src/app/controllers/tableOpsMutationCommands.ts
@@ -134,9 +134,15 @@ export function resolveLocationTableMutation(
     getActiveSectionIndex(current),
   );
   if (!location) return null;
-  const targetBlocks = getTargetBlocks(current, location.zone).map(cloneBlock);
-  const tableBlock = targetBlocks[location.blockIndex] as EditorTableNode;
-  if (!tableBlock || tableBlock.type !== "table") return null;
+
+  const currentBlocks = getTargetBlocks(current, location.zone);
+  const originalTableBlock = currentBlocks[location.blockIndex];
+  if (!originalTableBlock || originalTableBlock.type !== "table") return null;
+
+  const tableBlock = cloneBlock(originalTableBlock) as EditorTableNode;
+  const targetBlocks = [...currentBlocks];
+  targetBlocks[location.blockIndex] = tableBlock;
+
   return { tableBlock, location, targetBlocks };
 }
 

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,7 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Optimize document state cloning to eliminate severe lag during typical interactions.
Replaced entire-document cloning with referential sharing during selection updates, and replaced blanket array `.map(cloneBlock)` calls with targeted table cloning in mutation and cell-spanning operations. This retains structural sharing across the state and significantly reduces `input-to-layout` latency.

---
*PR created automatically by Jules for task [10583491911390163340](https://jules.google.com/task/10583491911390163340) started by @celsowm*