### PR TITLE
perf: fix layout thrashing on selection drag by restoring structural sharing

### DIFF
--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,6 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,

--- a/src/ui/app/useEditorAppState.ts
+++ b/src/ui/app/useEditorAppState.ts
@@ -16,7 +16,7 @@ export function createEditorAppState(options: {
   getStateSnapshot: () => EditorState;
 } {
   const initialEditorState = options.initialState
-    ? cloneEditorState(options.initialState)
+    ? options.initialState
     : options.initialDocument
       ? createEditorStateFromDocument(options.initialDocument)
       : createInitialEditorState();


### PR DESCRIPTION
Fixes massive input-to-layout latency (4000ms+) reported during dragging.

The root cause was that `applySelectionToStatePreservingStructure` and `useEditorAppState` were calling `cloneEditorState`, which performs a deep recursive clone of the entire document block tree. This destroyed structural sharing across the entire editor state, causing React/Solid updates and measurements to evaluate every single node instead of just the modified selection.

The fix replaces the deep cloning with a simple spread of the top-level state, correctly preserving the immutable references of the underlying `document` object.

---
*PR created automatically by Jules for task [16340791432055554032](https://jules.google.com/task/16340791432055554032) started by @celsowm*