### PR TITLE
Fix performance issue with selection drag deep cloning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vue": "^3.5.39"
       },
       "peerDependencies": {
-        "react": ">=18",
+        "react": ">=17",
         "vue": ">=3"
       },
       "peerDependenciesMeta": {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+1. **Analyze the performance issue**: The logs indicate a severe performance problem related to `input-to-layout` duration and subsequent drag selection events. The logs specifically mention a delay around input and backspace which also seems tied to structural changes or drag selection.
+2. **Examine `cloneEditorState` usage**: A key suspect for performance degradation in React state updates is deep cloning, specifically the `cloneEditorState` function. I will examine `createEditorInteractionRuntime.ts` where it is used.
+3. **Refactor `createEditorTableOperations`**: In `src/ui/app/createEditorInteractionRuntime.ts`, `applySelectionToStatePreservingStructure` currently uses `cloneEditorState(current).document`. This defeats structural sharing and causes a massive layout thrash by creating entirely new references for every document element. The solution is to remove `cloneEditorState(current).document` and just use `current.document`.
+4. **Pre-commit step**: Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.
+5. **Submit changes**: Submit the PR with changes to `src/ui/app/createEditorInteractionRuntime.ts`.

--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,7 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
+      document: current.document,
       selection: nextSelection,
     }),
     focusInput,


### PR DESCRIPTION
Fixes severe performance lag (evident in `input-to-layout` duration metrics) when dragging to select text. This occurred because `applySelectionToStatePreservingStructure` was deep-cloning the entire document via `cloneEditorState` instead of just propagating the existing reference, destroying React's ability to bail out of rendering unmodified document blocks during fast selection updates.

---
*PR created automatically by Jules for task [17918227087030876665](https://jules.google.com/task/17918227087030876665) started by @celsowm*