### PR TITLE
perf: fix severe input lag by preserving structural sharing in selection updates

### DIFF
--- a/src/ui/app/createEditorInteractionRuntime.ts
+++ b/src/ui/app/createEditorInteractionRuntime.ts
@@ -125,7 +125,6 @@ function createEditorInteractionRuntimeImpl(
     applyTransactionalState,
     applySelectionToStatePreservingStructure: (current, nextSelection) => ({
       ...current,
-      document: cloneEditorState(current).document,
       selection: nextSelection,
     }),
     focusInput,

--- a/src/ui/app/useEditorAppState.ts
+++ b/src/ui/app/useEditorAppState.ts
@@ -16,7 +16,7 @@ export function createEditorAppState(options: {
   getStateSnapshot: () => EditorState;
 } {
   const initialEditorState = options.initialState
-    ? cloneEditorState(options.initialState)
+    ? options.initialState
     : options.initialDocument
       ? createEditorStateFromDocument(options.initialDocument)
       : createInitialEditorState();


### PR DESCRIPTION
Fixes a critical performance issue where `applySelectionToStatePreservingStructure` was inadvertently deep-cloning the entire `document` via `cloneEditorState` on every selection change, causing operations to take multiple seconds. By keeping the structural sharing pattern and only updating the `selection`, editor performance remains fast during text selection and typing. Also removed `cloneEditorState` on initial hook state setup.

---
*PR created automatically by Jules for task [7781862113181918119](https://jules.google.com/task/7781862113181918119) started by @celsowm*