### PR TITLE
perf: Optimize bookmark anchor transformation fast path

### DIFF
--- a/src/core/document/bookmarkAnchors.ts
+++ b/src/core/document/bookmarkAnchors.ts
@@ -134,24 +134,31 @@ export function transformBookmarksAcrossParagraphEdit(
   oldParagraphs: EditorParagraphNode[],
   newParagraphs: EditorParagraphNode[],
 ): EditorBookmarks {
-  const old = buildStream(oldParagraphs);
-
   // Fast path: does any anchor actually live in the edited zone?
   let relevant = false;
-  for (const id of bookmarks.order) {
-    const bm = bookmarks.items[id];
-    if (!bm) continue;
-    if (
-      (bm.start && old.baseById.has(bm.start.paragraphId)) ||
-      (bm.end && old.baseById.has(bm.end.paragraphId))
-    ) {
-      relevant = true;
-      break;
+
+  if (bookmarks.order.length > 0) {
+    const bookmarkParagraphIds = new Set<string>();
+    for (const id of bookmarks.order) {
+      const bm = bookmarks.items[id];
+      if (!bm) continue;
+      if (bm.start) bookmarkParagraphIds.add(bm.start.paragraphId);
+      if (bm.end) bookmarkParagraphIds.add(bm.end.paragraphId);
+    }
+
+    for (const paragraph of oldParagraphs) {
+      if (bookmarkParagraphIds.has(paragraph.id)) {
+        relevant = true;
+        break;
+      }
     }
   }
+
   if (!relevant) {
     return bookmarks;
   }
+
+  const old = buildStream(oldParagraphs);
 
   const next = buildStream(newParagraphs);
   if (old.text === next.text) {


### PR DESCRIPTION
Resolves the severe input latency during text editing by deferring the heavy text stream generation in `transformBookmarksAcrossParagraphEdit` until necessary.

---
*PR created automatically by Jules for task [16439206805520539767](https://jules.google.com/task/16439206805520539767) started by @celsowm*