### PR TITLE
perf: optimize backspace by lazily building text stream in range anchors

### DIFF
--- a/src/core/document/rangeAnchors.ts
+++ b/src/core/document/rangeAnchors.ts
@@ -115,15 +115,18 @@ export function transformTextRangeRegistryAcrossParagraphEdit<
   oldParagraphs: EditorParagraphNode[],
   newParagraphs: EditorParagraphNode[],
 ): Registry {
-  const old = buildStream(oldParagraphs);
+  const oldParagraphIds = new Set<string>();
+  for (const paragraph of oldParagraphs) {
+    oldParagraphIds.add(paragraph.id);
+  }
 
   let relevant = false;
   for (const id of registry.order) {
     const item = registry.items[id];
     if (!item) continue;
     if (
-      (item.start && old.baseById.has(item.start.paragraphId)) ||
-      (item.end && old.baseById.has(item.end.paragraphId))
+      (item.start && oldParagraphIds.has(item.start.paragraphId)) ||
+      (item.end && oldParagraphIds.has(item.end.paragraphId))
     ) {
       relevant = true;
       break;
@@ -133,6 +136,7 @@ export function transformTextRangeRegistryAcrossParagraphEdit<
     return registry;
   }
 
+  const old = buildStream(oldParagraphs);
   const next = buildStream(newParagraphs);
   if (old.text === next.text) {
     return registry;


### PR DESCRIPTION
Optimizes `transformTextRangeRegistryAcrossParagraphEdit` to skip the costly `buildStream` execution when there are no intersecting range items.

---
*PR created automatically by Jules for task [1349289041967835559](https://jules.google.com/task/1349289041967835559) started by @celsowm*